### PR TITLE
Use implicit super()

### DIFF
--- a/py14/transpiler.py
+++ b/py14/transpiler.py
@@ -209,13 +209,13 @@ class CppTranspiler(CLikeTranspiler):
 
     def visit_Str(self, node):
         """Use a C++ 14 string literal instead of raw string"""
-        return "std::string {" + super(CppTranspiler, self).visit_Str(node) + "}"
+        return "std::string {" + super().visit_Str(node) + "}"
 
     def visit_Name(self, node):
         if node.id == "None":
             return "nullptr"
         else:
-            return super(CppTranspiler, self).visit_Name(node)
+            return super().visit_Name(node)
 
     def visit_Constant(self, node):
         if node.value is True:
@@ -225,7 +225,7 @@ class CppTranspiler(CLikeTranspiler):
         elif isinstance(node.value, str):
             return self.visit_Str(node)
         else:
-            return super(CppTranspiler, self).visit_Constant(node)
+            return super().visit_Constant(node)
 
     def visit_If(self, node):
         body_vars = set([get_id(v) for v in node.scopes[-1].body_vars])
@@ -247,7 +247,7 @@ class CppTranspiler(CLikeTranspiler):
             buf.append("}")
             return "\n".join(buf)
         else:
-            return "".join(var_definitions) + super(CppTranspiler, self).visit_If(node)
+            return "".join(var_definitions) + super().visit_If(node)
 
     def visit_UnaryOp(self, node):
         if isinstance(node.op, ast.USub):
@@ -257,7 +257,7 @@ class CppTranspiler(CLikeTranspiler):
             else:
                 return "-({0})".format(self.visit(node.operand))
         else:
-            return super(CppTranspiler, self).visit_UnaryOp(node)
+            return super().visit_UnaryOp(node)
 
     def visit_BinOp(self, node):
         if (
@@ -269,7 +269,7 @@ class CppTranspiler(CLikeTranspiler):
                 self.visit(node.right), self.visit(node.left.elts[0])
             )
         else:
-            return super(CppTranspiler, self).visit_BinOp(node)
+            return super().visit_BinOp(node)
 
     def visit_Module(self, node):
         buf = [self.visit(b) for b in node.body]

--- a/py2many/clike.py
+++ b/py2many/clike.py
@@ -58,7 +58,7 @@ class CLikeTranspiler(ast.NodeVisitor):
         if type(node) in symbols:
             return c_symbol(node)
         else:
-            return super(CLikeTranspiler, self).visit(node)
+            return super().visit(node)
 
     def visit_Name(self, node):
         if node.id in self.builtin_constants:

--- a/py2many/context.py
+++ b/py2many/context.py
@@ -93,7 +93,7 @@ class VariableTransformer(ast.NodeTransformer, ScopeMixin):
 
     def visit(self, node):
         with self.enter_scope(node):
-            return super(VariableTransformer, self).visit(node)
+            return super().visit(node)
 
     def visit_Assign(self, node):
         for target in node.targets:

--- a/py2many/scope.py
+++ b/py2many/scope.py
@@ -83,4 +83,4 @@ class ScopeTransformer(ast.NodeTransformer, ScopeMixin):
     def visit(self, node):
         with self.enter_scope(node):
             node.scopes = ScopeList(self.scopes)
-            return super(ScopeTransformer, self).visit(node)
+            return super().visit(node)

--- a/pydart/transpiler.py
+++ b/pydart/transpiler.py
@@ -212,7 +212,7 @@ class DartTranspiler(CLikeTranspiler):
             return s
 
     def visit_Str(self, node):
-        return "" + super(DartTranspiler, self).visit_Str(node) + ""
+        return "" + super().visit_Str(node) + ""
 
     def visit_Bytes(self, node):
         bytes_str = "{0}".format(node.s)
@@ -230,7 +230,7 @@ class DartTranspiler(CLikeTranspiler):
                 right, left
             )  # is it even more?
 
-        return super(DartTranspiler, self).visit_Compare(node)
+        return super().visit_Compare(node)
 
     def visit_Name(self, node):
         if node.id == "None":
@@ -246,7 +246,7 @@ class DartTranspiler(CLikeTranspiler):
         elif node.value is None:
             return "None"
         else:
-            return super(DartTranspiler, self).visit_NameConstant(node)
+            return super().visit_NameConstant(node)
 
     def visit_If(self, node):
         body_vars = set([get_id(v) for v in node.scopes[-1].body_vars])
@@ -279,7 +279,7 @@ class DartTranspiler(CLikeTranspiler):
             else:
                 return "-({0})".format(self.visit(node.operand))
         else:
-            return super(DartTranspiler, self).visit_UnaryOp(node)
+            return super().visit_UnaryOp(node)
 
     def visit_BinOp(self, node):
         if (
@@ -291,7 +291,7 @@ class DartTranspiler(CLikeTranspiler):
                 self.visit(node.right), self.visit(node.left.elts[0])
             )
         else:
-            return super(DartTranspiler, self).visit_BinOp(node)
+            return super().visit_BinOp(node)
 
     def visit_Module(self, node):
         buf = []

--- a/pygo/transpiler.py
+++ b/pygo/transpiler.py
@@ -213,7 +213,7 @@ class GoTranspiler(CLikeTranspiler):
         return self.visit(node.value)
 
     def visit_Str(self, node):
-        return "" + super(GoTranspiler, self).visit_Str(node) + ""
+        return "" + super().visit_Str(node) + ""
 
     def visit_Bytes(self, node):
         bytes_str = "{0}".format(node.s)
@@ -231,13 +231,13 @@ class GoTranspiler(CLikeTranspiler):
                 right, left
             )  # is it even more?
 
-        return super(GoTranspiler, self).visit_Compare(node)
+        return super().visit_Compare(node)
 
     def visit_Name(self, node):
         if node.id == "None":
             return "None"
         else:
-            return super(GoTranspiler, self).visit_Name(node)
+            return super().visit_Name(node)
 
     def visit_NameConstant(self, node):
         if node.value is True:
@@ -247,7 +247,7 @@ class GoTranspiler(CLikeTranspiler):
         elif node.value is None:
             return "nil"
         else:
-            return super(GoTranspiler, self).visit_NameConstant(node)
+            return super().visit_NameConstant(node)
 
     def visit_If(self, node):
         body_vars = set([get_id(v) for v in node.scopes[-1].body_vars])
@@ -270,7 +270,7 @@ class GoTranspiler(CLikeTranspiler):
             else:
                 return "-({0})".format(self.visit(node.operand))
         else:
-            return super(GoTranspiler, self).visit_UnaryOp(node)
+            return super().visit_UnaryOp(node)
 
     def visit_BinOp(self, node):
         if (
@@ -282,7 +282,7 @@ class GoTranspiler(CLikeTranspiler):
                 self.visit(node.right), self.visit(node.left.elts[0])
             )
         else:
-            return super(GoTranspiler, self).visit_BinOp(node)
+            return super().visit_BinOp(node)
 
     def visit_Module(self, node):
         buf = []

--- a/pyjl/transpiler.py
+++ b/pyjl/transpiler.py
@@ -198,7 +198,7 @@ class JuliaTranspiler(CLikeTranspiler):
         return self.visit(node.value)
 
     def visit_Str(self, node):
-        return "" + super(JuliaTranspiler, self).visit_Str(node) + ""
+        return "" + super().visit_Str(node) + ""
 
     def visit_Bytes(self, node):
         bytes_str = "{0}".format(node.s)
@@ -216,13 +216,13 @@ class JuliaTranspiler(CLikeTranspiler):
                 right, left
             )  # is it even more?
 
-        return super(JuliaTranspiler, self).visit_Compare(node)
+        return super().visit_Compare(node)
 
     def visit_Name(self, node):
         if node.id == "None":
             return "None"
         else:
-            return super(JuliaTranspiler, self).visit_Name(node)
+            return super().visit_Name(node)
 
     def visit_NameConstant(self, node):
         if node.value is True:
@@ -232,7 +232,7 @@ class JuliaTranspiler(CLikeTranspiler):
         elif node.value is None:
             return "None"
         else:
-            return super(JuliaTranspiler, self).visit_NameConstant(node)
+            return super().visit_NameConstant(node)
 
     def visit_If(self, node):
         body_vars = set([get_id(v) for v in node.scopes[-1].body_vars])
@@ -275,7 +275,7 @@ class JuliaTranspiler(CLikeTranspiler):
             else:
                 return "-({0})".format(self.visit(node.operand))
         else:
-            return super(JuliaTranspiler, self).visit_UnaryOp(node)
+            return super().visit_UnaryOp(node)
 
     def visit_BinOp(self, node):
         if (
@@ -287,7 +287,7 @@ class JuliaTranspiler(CLikeTranspiler):
                 self.visit(node.right), self.visit(node.left.elts[0])
             )
         else:
-            return super(JuliaTranspiler, self).visit_BinOp(node)
+            return super().visit_BinOp(node)
 
     def visit_Module(self, node):
         buf = []

--- a/pykt/transpiler.py
+++ b/pykt/transpiler.py
@@ -196,7 +196,7 @@ class KotlinTranspiler(CLikeTranspiler):
         return self.visit(node.value)
 
     def visit_Str(self, node):
-        return "" + super(KotlinTranspiler, self).visit_Str(node) + ""
+        return "" + super().visit_Str(node) + ""
 
     def visit_Bytes(self, node):
         bytes_str = "{0}".format(node.s)
@@ -214,13 +214,13 @@ class KotlinTranspiler(CLikeTranspiler):
                 right, left
             )  # is it even more?
 
-        return super(KotlinTranspiler, self).visit_Compare(node)
+        return super().visit_Compare(node)
 
     def visit_Name(self, node):
         if node.id == "None":
             return "None"
         else:
-            return super(KotlinTranspiler, self).visit_Name(node)
+            return super().visit_Name(node)
 
     def visit_NameConstant(self, node):
         if node.value is True:
@@ -230,7 +230,7 @@ class KotlinTranspiler(CLikeTranspiler):
         elif node.value is None:
             return "None"
         else:
-            return super(KotlinTranspiler, self).visit_NameConstant(node)
+            return super().visit_NameConstant(node)
 
     def visit_If(self, node):
         body_vars = set([get_id(v) for v in node.scopes[-1].body_vars])
@@ -253,7 +253,7 @@ class KotlinTranspiler(CLikeTranspiler):
             else:
                 return "-({0})".format(self.visit(node.operand))
         else:
-            return super(KotlinTranspiler, self).visit_UnaryOp(node)
+            return super().visit_UnaryOp(node)
 
     def visit_BinOp(self, node):
         if (
@@ -265,7 +265,7 @@ class KotlinTranspiler(CLikeTranspiler):
             elt = self.visit(node.left.elts[0])
             return f"Array({num}) {{ {elt} }}"
         else:
-            return super(KotlinTranspiler, self).visit_BinOp(node)
+            return super().visit_BinOp(node)
 
     def visit_Module(self, node):
         buf = []

--- a/pynim/transpiler.py
+++ b/pynim/transpiler.py
@@ -194,7 +194,7 @@ class NimTranspiler(CLikeTranspiler):
         return self.visit(node.value)
 
     def visit_Str(self, node):
-        return "" + super(NimTranspiler, self).visit_Str(node) + ""
+        return "" + super().visit_Str(node) + ""
 
     def visit_Bytes(self, node):
         bytes_str = "{0}".format(node.s)
@@ -212,13 +212,13 @@ class NimTranspiler(CLikeTranspiler):
                 right, left
             )  # is it even more?
 
-        return super(NimTranspiler, self).visit_Compare(node)
+        return super().visit_Compare(node)
 
     def visit_Name(self, node):
         if node.id == "None":
             return "None"
         else:
-            return super(NimTranspiler, self).visit_Name(node)
+            return super().visit_Name(node)
 
     def visit_NameConstant(self, node):
         if node.value is True:
@@ -228,7 +228,7 @@ class NimTranspiler(CLikeTranspiler):
         elif node.value is None:
             return "None"
         else:
-            return super(NimTranspiler, self).visit_NameConstant(node)
+            return super().visit_NameConstant(node)
 
     def visit_If(self, node):
         body_vars = set([get_id(v) for v in node.scopes[-1].body_vars])
@@ -269,7 +269,7 @@ class NimTranspiler(CLikeTranspiler):
             else:
                 return "-({0})".format(self.visit(node.operand))
         else:
-            return super(NimTranspiler, self).visit_UnaryOp(node)
+            return super().visit_UnaryOp(node)
 
     def visit_BinOp(self, node):
         if (
@@ -281,7 +281,7 @@ class NimTranspiler(CLikeTranspiler):
                 self.visit(node.right), self.visit(node.left.elts[0])
             )
         else:
-            return super(NimTranspiler, self).visit_BinOp(node)
+            return super().visit_BinOp(node)
 
     def visit_Module(self, node):
         buf = []

--- a/pyrs/transpiler.py
+++ b/pyrs/transpiler.py
@@ -214,7 +214,7 @@ class RustTranspiler(CLikeTranspiler):
             return s
 
     def visit_Str(self, node):
-        return "" + super(RustTranspiler, self).visit_Str(node) + ""
+        return "" + super().visit_Str(node) + ""
 
     def visit_Bytes(self, node):
         bytes_str = "{0}".format(node.s)
@@ -232,13 +232,13 @@ class RustTranspiler(CLikeTranspiler):
                 right, left
             )  # is it even more?
 
-        return super(RustTranspiler, self).visit_Compare(node)
+        return super().visit_Compare(node)
 
     def visit_Name(self, node):
         if node.id == "None":
             return "None"
         else:
-            return super(RustTranspiler, self).visit_Name(node)
+            return super().visit_Name(node)
 
     def visit_NameConstant(self, node):
         if node.value is True:
@@ -248,7 +248,7 @@ class RustTranspiler(CLikeTranspiler):
         elif node.value is None:
             return "None"
         else:
-            return super(RustTranspiler, self).visit_NameConstant(node)
+            return super().visit_NameConstant(node)
 
     def visit_If(self, node):
         body_vars = set([get_id(v) for v in node.scopes[-1].body_vars])
@@ -269,9 +269,7 @@ class RustTranspiler(CLikeTranspiler):
             buf.append("}")
             return "\n".join(buf)
         else:
-            return "".join(var_definitions) + super(RustTranspiler, self).visit_If(
-                node, use_parens=False
-            )
+            return "".join(var_definitions) + super().visit_If(node, use_parens=False)
 
     def visit_While(self, node):
         return super().visit_While(node, use_parens=False)
@@ -284,7 +282,7 @@ class RustTranspiler(CLikeTranspiler):
             else:
                 return "-({0})".format(self.visit(node.operand))
         else:
-            return super(RustTranspiler, self).visit_UnaryOp(node)
+            return super().visit_UnaryOp(node)
 
     def visit_BinOp(self, node):
         if (
@@ -296,7 +294,7 @@ class RustTranspiler(CLikeTranspiler):
                 self.visit(node.right), self.visit(node.left.elts[0])
             )
         else:
-            return super(RustTranspiler, self).visit_BinOp(node)
+            return super().visit_BinOp(node)
 
     def visit_Module(self, node):
         buf = []


### PR DESCRIPTION
Explicit super are unnecessary when writing Python 3+ only
code.  Removing them means the reader doesn't need to check
if the super args are doing anything funky.