### PR TITLE
rust: infer list index type and widen if necessary

### DIFF
--- a/py14/tests/test_context.py
+++ b/py14/tests/test_context.py
@@ -46,12 +46,12 @@ class TestVariableTranformer:
             "   results.append(x)",
             "   return results",
         )
-        assert len(source.vars) == 0
+        assert len(source.vars) == 1
         assert len(source.body[0].vars) == 3
 
     def test_local_vars_of_function_with_args(self):
         source = parse("def foo(x, y):", "   return x + y")
-        assert len(source.vars) == 0
+        assert len(source.vars) == 1
         assert len(source.body[0].vars) == 2
 
     def test_subscripts_are_ignored(self):
@@ -70,7 +70,7 @@ class TestVariableTranformer:
             "   results.append(x)",
             "   return results",
         )
-        assert len(source.vars) == 1
+        assert len(source.vars) == 2
         assert len(source.body[1].vars) == 1
 
     def test_vars_inside_loop(self):
@@ -81,5 +81,5 @@ class TestVariableTranformer:
             "       results.append(x)",
             "   return results",
         )
-        assert len(source.vars) == 0
+        assert len(source.vars) == 1
         assert len(source.body[0].body[1].vars) == 1

--- a/py14/transpiler.py
+++ b/py14/transpiler.py
@@ -304,13 +304,7 @@ class CppTranspiler(CLikeTranspiler):
         if isinstance(node.slice, ast.Ellipsis):
             raise NotImplementedError("Ellipsis not supported")
 
-        if sys.version_info < (3, 9, 0):
-            if not isinstance(node.slice, ast.Index):
-                raise NotImplementedError("Advanced Slicing not supported")
-            slice_value = node.slice.value
-        else:
-            slice_value = node.slice
-
+        slice_value = self._slice_value(node)
         return "{0}[{1}]".format(value, self.visit(slice_value))
 
     def visit_Tuple(self, node):

--- a/py2many/analysis.py
+++ b/py2many/analysis.py
@@ -22,6 +22,8 @@ if sys.version_info[0] >= 3:
             return var.id
         elif isinstance(var, ast.arg):
             return var.arg
+        elif isinstance(var, ast.FunctionDef):
+            return var.name
 
 
 else:

--- a/py2many/clike.py
+++ b/py2many/clike.py
@@ -56,6 +56,9 @@ class CLikeTranspiler(ast.NodeVisitor):
     def comment(self, text):
         return f"/* {text} */"
 
+    def _cast(self, name: str, to) -> str:
+        return f"({to}) {name}"
+
     def visit(self, node):
         if type(node) == ast.Pass:
             return self.comment("pass")

--- a/py2many/clike.py
+++ b/py2many/clike.py
@@ -1,4 +1,6 @@
 import ast
+import sys
+
 from py2many.analysis import get_id
 
 
@@ -58,6 +60,16 @@ class CLikeTranspiler(ast.NodeVisitor):
 
     def _cast(self, name: str, to) -> str:
         return f"({to}) {name}"
+
+    def _slice_value(self, node: ast.AST):
+        # 3.9 compatibility shim
+        if sys.version_info < (3, 9, 0):
+            if not isinstance(node.slice, ast.Index):
+                raise NotImplementedError("Advanced Slicing not supported")
+            slice_value = node.slice.value
+        else:
+            slice_value = node.slice
+        return slice_value
 
     def visit(self, node):
         if type(node) == ast.Pass:

--- a/py2many/context.py
+++ b/py2many/context.py
@@ -48,6 +48,9 @@ class VariableTransformer(ast.NodeTransformer, ScopeMixin):
 
     def visit_FunctionDef(self, node):
         node.vars = []
+        # So function signatures are accessible even after they're
+        # popped from the scope
+        self.scopes[-2].vars.append(node)
         for arg in node.args.args:
             arg.assigned_from = node
             node.vars.append(arg)

--- a/pyrs/tests/test_context.py
+++ b/pyrs/tests/test_context.py
@@ -46,12 +46,12 @@ class TestVariableTranformer:
             "   results.append(x)",
             "   return results",
         )
-        assert len(source.vars) == 0
+        assert len(source.vars) == 1
         assert len(source.body[0].vars) == 3
 
     def test_local_vars_of_function_with_args(self):
         source = parse("def foo(x, y):", "   return x + y")
-        assert len(source.vars) == 0
+        assert len(source.vars) == 1
         assert len(source.body[0].vars) == 2
 
     def test_subscripts_are_ignored(self):
@@ -70,7 +70,7 @@ class TestVariableTranformer:
             "   results.append(x)",
             "   return results",
         )
-        assert len(source.vars) == 1
+        assert len(source.vars) == 2
         assert len(source.body[1].vars) == 1
 
     def test_vars_inside_loop(self):
@@ -81,5 +81,5 @@ class TestVariableTranformer:
             "       results.append(x)",
             "   return results",
         )
-        assert len(source.vars) == 0
+        assert len(source.vars) == 1
         assert len(source.body[0].body[1].vars) == 1

--- a/pyrs/transpiler.py
+++ b/pyrs/transpiler.py
@@ -411,7 +411,7 @@ class RustTranspiler(CLikeTranspiler):
     def visit_Subscript(self, node):
         value = self.visit(node.value)
         index = self.visit(node.slice)
-        index_typename = get_inferred_type(node.slice.value)
+        index_typename = get_inferred_type(self._slice_value(node))
         if index_typename is not None and (
             index_typename != "u64" or index_typename != "usize"
         ):

--- a/tests/expected/binit.rs
+++ b/tests/expected/binit.rs
@@ -20,7 +20,7 @@ fn bin_it(limits: Vec<i32>, data: Vec<i32>) -> Vec<i32> {
         bins.push(0);
     }
     for d in data {
-        bins[bisect_right(limits, d)] += 1;
+        bins[bisect_right(limits, d) as usize] += 1;
     }
     return bins;
 }

--- a/tests/expected/fib.cpp
+++ b/tests/expected/fib.cpp
@@ -7,6 +7,6 @@ template <typename T1> auto fib(T1 i) {
 
 int main(int argc, char **argv) {
   py14::sys::argv = std::vector<std::string>(argv, argv + argc);
-  auto rv = fib(5);
+  int rv = fib(5);
   std::cout << rv << std::endl;
 }

--- a/tests/expected/fib.dart
+++ b/tests/expected/fib.dart
@@ -9,6 +9,6 @@ int fib(int i) {
 }
 
 void main() {
-  var rv = fib(5);
+  int rv = fib(5);
   print(sprintf("%s", [rv]));
 }

--- a/tests/expected/fib.go
+++ b/tests/expected/fib.go
@@ -12,6 +12,6 @@ func fib(i int) int {
 }
 
 func main() {
-	rv := fib(5)
+	var rv int = fib(5)
 	fmt.Printf("%v\n", rv)
 }

--- a/tests/expected/fib.rs
+++ b/tests/expected/fib.rs
@@ -6,6 +6,6 @@ fn fib(i: i32) -> i32 {
 }
 
 fn main() {
-    let rv: _ = fib(5);
+    let rv: i32 = fib(5);
     println!("{}", rv);
 }

--- a/tests/expected/infer_ops.cpp
+++ b/tests/expected/infer_ops.cpp
@@ -41,7 +41,7 @@ template <typename T1, typename T2> auto mul(T1 x, T2 y) { return x * y; }
 template <typename T1, typename T2> auto fadd(T1 x, T2 y) { return x + y; }
 
 inline void show() {
-  auto rv = fadd(6, 6.0);
+  double rv = fadd(6, 6.0);
   REQUIRE(rv == 12);
   std::cout << rv << std::endl;
 }

--- a/tests/expected/infer_ops.dart
+++ b/tests/expected/infer_ops.dart
@@ -67,7 +67,7 @@ double fadd(int x, double y) {
 }
 
 show() {
-  var rv = fadd(6, 6.0);
+  double rv = fadd(6, 6.0);
   assert(rv == 12);
   print(sprintf("%s", [rv]));
 }

--- a/tests/expected/infer_ops.go
+++ b/tests/expected/infer_ops.go
@@ -70,7 +70,7 @@ func fadd(x int8, y float64) float64 {
 }
 
 func show() {
-	rv := fadd(6, 6.0)
+	var rv float64 = fadd(6, 6.0)
 	if !(rv == 12) {
 		panic("assert")
 	}

--- a/tests/expected/infer_ops.rs
+++ b/tests/expected/infer_ops.rs
@@ -64,7 +64,7 @@ fn fadd(x: i8, y: f32) -> f32 {
 }
 
 fn show() {
-    let rv: _ = fadd(6, 6.0);
+    let rv: f32 = fadd(6, 6.0);
     assert!(rv == 12);
     println!("{}", rv);
 }


### PR DESCRIPTION
Rust expects vector indices to be `usize`.

Tested via:

```
from ctypes import c_int32

def bar() -> c_int32:
    return c_int32(2)

def main():
    d = [1, 2, 3]
    i: c_int32 = 2
    d[i] = 4
    d[bar()] += 1

```

Generates:

```
fn bar() -> i32 {
    return c_int32(2);
}

fn main() {
    let d = vec![1, 2, 3];
    let i: i32 = 2;
    d[i as usize] = 4;
    d[bar() as usize] += 1;
}
```