### PR TITLE
julia: unmask test failures

### DIFF
--- a/tests/expected/binit.jl
+++ b/tests/expected/binit.jl
@@ -16,7 +16,7 @@ end
 
 function bin_it(limits::Array{Int64}, data::Array{Int64})::Array{Int64}
     bins = [0]
-    for x in limits
+    for _x in limits
         bins.push(0)
     end
     for d in data

--- a/tests/expected/fib.jl
+++ b/tests/expected/fib.jl
@@ -4,3 +4,8 @@ function fib(i::Int64)::Int64
     end
     return (fib((i - 1)) + fib((i - 2)))
 end
+
+function main()
+    rv = fib(5)
+    println(join([rv], " "))
+end

--- a/tests/expected/print.jl
+++ b/tests/expected/print.jl
@@ -1,5 +1,9 @@
-function main()
+function show()
     println(join([2], " "))
     println(join(["b"], " "))
     println(join([2, "b"], " "))
+end
+
+function main()
+    show()
 end

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,7 +17,7 @@ COMPILERS = {
     "cpp": ["clang", "-std=c++14"],
     "dart": ["dart", "compile", "exe"],
     "go": ["go", "tool", "compile"],
-    "julia": None,
+    "julia": ["julia", "--compiled-modules=yes"],
     "kotlin": ["kotlinc"],
     "nim": ["nim", "compile", "--nimcache:."],
     "rust": ["cargo", "script", "--build-only", "--debug"],


### PR DESCRIPTION
Add a compiler, so we can detect out of sync expected outputs