### PR TITLE
backends: use _typename_from_annotation

### DIFF
--- a/py14/transpiler.py
+++ b/py14/transpiler.py
@@ -121,6 +121,7 @@ class CppTranspiler(CLikeTranspiler):
         self._headers = []
         self._usings = set([])
         self.use_catch_test_cases = False
+        self._container_type_map = self.CONTAINER_TYPES
 
     def headers(self, meta: InferMeta):
         self._headers.append('#include "py14/runtime/sys.h"')
@@ -419,8 +420,6 @@ class CppTranspiler(CLikeTranspiler):
 
     def visit_AnnAssign(self, node):
         target, type_str, val = super().visit_AnnAssign(node)
-        if type_str in self._type_map:
-            type_str = self._type_map[type_str]
         return f"{type_str} {target} = {val};"
 
     def visit_Print(self, node):

--- a/py2many/clike.py
+++ b/py2many/clike.py
@@ -103,11 +103,11 @@ class CLikeTranspiler(ast.NodeVisitor):
             return self._default_type
         return self._combine_value_index(value_type, index_type)
 
-    def _typename_from_annotation(self, node) -> str:
+    def _typename_from_annotation(self, node, attr="annotation") -> str:
         default_type = self._default_type
         typename = default_type
-        if hasattr(node, "annotation"):
-            typename = node.annotation
+        if hasattr(node, attr):
+            typename = getattr(node, attr)
             if isinstance(typename, ast.Subscript):
                 # Store a tuple like (List, int) or (Dict, (str, int)) for container types
                 # in node.container_type
@@ -141,9 +141,6 @@ class CLikeTranspiler(ast.NodeVisitor):
     def visit_Name(self, node):
         if node.id in self.builtin_constants:
             return node.id.lower()
-        elif hasattr(node, "is_annotation"):
-            if node.id in self._type_map:
-                return self._type_map[node.id]
         return node.id
 
     def visit_NameConstant(self, node):
@@ -248,7 +245,7 @@ class CLikeTranspiler(ast.NodeVisitor):
 
     def visit_AnnAssign(self, node):
         target = self.visit(node.target)
-        type_str = self.visit(node.annotation)
+        type_str = self._typename_from_annotation(node)
         val = self.visit(node.value) if node.value is not None else None
         return (target, type_str, val)
 

--- a/pydart/transpiler.py
+++ b/pydart/transpiler.py
@@ -73,7 +73,8 @@ class DartTranspiler(CLikeTranspiler):
         return_type = ""
         if not is_void_function(node):
             if node.returns:
-                return_type = "{0}".format(self.visit(node.returns))
+                typename = self._typename_from_annotation(node, attr="returns")
+                return_type = f"{typename}"
             else:
                 return_type = "RT"
                 typedecls.append("RT")
@@ -97,7 +98,7 @@ class DartTranspiler(CLikeTranspiler):
             return (None, "self")
         typename = "T"
         if node.annotation:
-            typename = self.visit(node.annotation)
+            typename = self._typename_from_annotation(node)
         return (typename, id)
 
     def visit_Lambda(self, node):

--- a/pygo/transpiler.py
+++ b/pygo/transpiler.py
@@ -75,7 +75,8 @@ class GoTranspiler(CLikeTranspiler):
         return_type = ""
         if not is_void_function(node):
             if node.returns:
-                return_type = " {0}".format(self.visit(node.returns))
+                typename = self._typename_from_annotation(node, attr="returns")
+                return_type = f" {typename}"
             else:
                 return_type = " RT"
                 typedecls.append("RT")
@@ -99,7 +100,7 @@ class GoTranspiler(CLikeTranspiler):
             return (None, "self")
         typename = "T"
         if node.annotation:
-            typename = self.visit(node.annotation)
+            typename = self._typename_from_annotation(node)
         return (typename, id)
 
     def visit_Lambda(self, node):

--- a/pyjl/transpiler.py
+++ b/pyjl/transpiler.py
@@ -83,7 +83,8 @@ class JuliaTranspiler(CLikeTranspiler):
         return_type = ""
         if not is_void_function(node):
             if node.returns:
-                return_type = "::{0}".format(self.visit(node.returns))
+                typename = self._typename_from_annotation(node, attr="returns")
+                return_type = f"::{typename}"
             else:
                 return_type = "::RT"
                 typedecls.append("RT")
@@ -107,7 +108,7 @@ class JuliaTranspiler(CLikeTranspiler):
             return (None, "self")
         typename = "T"
         if node.annotation:
-            typename = self.visit(node.annotation)
+            typename = self._typename_from_annotation(node)
         return (typename, id)
 
     def visit_Lambda(self, node):
@@ -157,8 +158,8 @@ class JuliaTranspiler(CLikeTranspiler):
 
         # small one liners are inlined here as lambdas
         small_dispatch_map = {
-            "int": lambda: f"i32::from({vargs[0]})",
-            "str": lambda: f"String::from({vargs[0]})",
+            "int": lambda: f"Int64({vargs[0]})",
+            "str": lambda: f"string({vargs[0]})",
             "len": lambda: f"length({vargs[0]})",
         }
         if fname in small_dispatch_map:

--- a/pykt/transpiler.py
+++ b/pykt/transpiler.py
@@ -68,7 +68,8 @@ class KotlinTranspiler(CLikeTranspiler):
         return_type = ""
         if not is_void_function(node):
             if node.returns:
-                return_type = ": {0}".format(self.visit(node.returns))
+                typename = self._typename_from_annotation(node, attr="returns")
+                return_type = f": {typename}"
             else:
                 return_type = ": RT"
                 typedecls.append("RT")
@@ -93,7 +94,7 @@ class KotlinTranspiler(CLikeTranspiler):
         id, _ = self._check_keyword(id)
         typename = "T"
         if node.annotation:
-            typename = self.visit(node.annotation)
+            typename = self._typename_from_annotation(node)
         return (typename, id)
 
     def visit_Lambda(self, node):

--- a/pynim/clike.py
+++ b/pynim/clike.py
@@ -8,6 +8,7 @@ nim_type_map = {
     "float": "float",
     "bytes": "openArray[byte]",
     "str": "String",
+    "bool": "bool",
     "c_int8": "int8",
     "c_int16": "int16",
     "c_int32": "int32",

--- a/pyrs/clike.py
+++ b/pyrs/clike.py
@@ -8,6 +8,7 @@ rust_type_map = {
     "float": "f32",
     "bytes": "&[u8]",
     "str": "&str",
+    "bool": "bool",
     "c_int8": "i8",
     "c_int16": "i16",
     "c_int32": "i32",

--- a/tests/cases/binit.py
+++ b/tests/cases/binit.py
@@ -7,7 +7,7 @@ from typing import List
 
 def bisect_right(data: List[int], item: int) -> int:
     low = 0
-    high = len(data)
+    high: int = int(len(data))
     while low < high:
         middle = int((low + high) / 2)
         if item < data[middle]:

--- a/tests/expected/binit.cpp
+++ b/tests/expected/binit.cpp
@@ -4,7 +4,7 @@
 
 template <typename T1, typename T2> auto bisect_right(T1 data, T2 item) {
   int low = 0;
-  auto high = data.size();
+  int high = py14::to_int(data.size());
   while (low < high) {
     auto middle = py14::to_int((low + high) / 2);
     if (item < data[middle]) {

--- a/tests/expected/binit.dart
+++ b/tests/expected/binit.dart
@@ -1,6 +1,6 @@
 int bisect_right(List<int> data, int item) {
   int low = 0;
-  var high = data.length;
+  int high = data.length.toInt();
   while (low < high) {
     var middle = ((low + high) / 2).toInt();
 

--- a/tests/expected/binit.go
+++ b/tests/expected/binit.go
@@ -6,7 +6,7 @@ import (
 
 func bisect_right(data []int, item int) int {
 	var low int = 0
-	high := len(data)
+	var high int = int(len(data))
 	for low < high {
 		middle := int(((low + high) / 2))
 		if item < data[middle] {

--- a/tests/expected/binit.jl
+++ b/tests/expected/binit.jl
@@ -1,9 +1,9 @@
 
 function bisect_right(data::Array{Int64}, item::Int64)::Int64
     low = 0
-    high = length(data)
+    high::Int64 = Int64(length(data))
     while low < high
-        middle = i32::from(((low + high) / 2))
+        middle = Int64(((low + high) / 2))
         if item < data[middle+1]
             high = middle
         else

--- a/tests/expected/binit.kt
+++ b/tests/expected/binit.kt
@@ -1,7 +1,7 @@
 
 fun bisect_right(data_: Array<Int>, item: Int): Int {
     var low = 0
-    var high = data_.size
+    var high: Int = data_.size.toInt()
     while (low < high) {
         val middle = ((low + high) / 2).toInt()
         if (item < data_[middle]) {

--- a/tests/expected/binit.nim
+++ b/tests/expected/binit.nim
@@ -1,7 +1,7 @@
 
 proc bisect_right(data: openArray[int], item: int): int =
   var low = 0
-  var high = len(data)
+  var high: int = int(len(data))
   while low < high:
     let middle = int(low + high / 2)
     if item < data[middle]:

--- a/tests/expected/binit.rs
+++ b/tests/expected/binit.rs
@@ -2,7 +2,7 @@ use std::collections;
 
 fn bisect_right(data: &Vec<i32>, item: i32) -> i32 {
     let mut low: i32 = 0;
-    let mut high: _ = data.len();
+    let mut high: i32 = data.len() as i32;
     while low < high {
         let middle: _ = i32::from(((low + high) / 2));
         if item < data[middle as usize] {


### PR DESCRIPTION
This gets us the exactly once translation from python types
to target language types

Also add type annotations to binit.py to help rust understand
that high is a i32