### PR TITLE
rust: RustLoopIndexRewriter

### DIFF
--- a/py2many/cli.py
+++ b/py2many/cli.py
@@ -18,7 +18,7 @@ from .context import add_variable_context, add_list_calls
 from .inference import infer_types
 
 from py14.transpiler import CppTranspiler, CppListComparisonRewriter
-from pyrs.transpiler import RustTranspiler
+from pyrs.transpiler import RustTranspiler, RustLoopIndexRewriter
 from pyjl.transpiler import JuliaTranspiler, JuliaMethodCallRewriter
 from pykt.transpiler import KotlinTranspiler
 from pynim.transpiler import NimTranspiler
@@ -79,7 +79,7 @@ def cpp_settings(args):
 
 
 def rust_settings(args):
-    return LanguageSettings(RustTranspiler(), ".rs", ["rustfmt"])
+    return LanguageSettings(RustTranspiler(), ".rs", ["rustfmt"], None, [], [RustLoopIndexRewriter()])
 
 
 def julia_settings(args):

--- a/tests/expected/binit.rs
+++ b/tests/expected/binit.rs
@@ -20,7 +20,7 @@ fn bin_it(limits: &Vec<i32>, data: &Vec<i32>) -> Vec<i32> {
         bins.push(0);
     }
     for d in data {
-        bins[bisect_right(&limits, d) as usize] += 1;
+        bins[bisect_right(&limits, *d) as usize] += 1;
     }
     return bins;
 }

--- a/tests/expected/global.rs
+++ b/tests/expected/global.rs
@@ -7,10 +7,10 @@ const code_b: &str = "b";
 const l_b: &[&str; 2] = &[code_a, code_b];
 fn main() {
     for i in l_a {
-        println!("{}", i);
+        println!("{}", *i);
     }
     for i in l_b {
-        println!("{}", i);
+        println!("{}", *i);
     }
     if vec!["a", "b"].iter().any(|&x| x == "a") {
         println!("{}", "OK");

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -57,7 +57,6 @@ COMPARABLE = [
 EXPECTED_COMPILE_FAILURES = [
     "binit.jl",  # https://github.com/adsharma/py2many/issues/80
     "binit.nim",  # https://github.com/adsharma/py2many/issues/19
-    "binit.rs",  # https://github.com/adsharma/py2many/issues/19
     "global.go",  # https://github.com/adsharma/py2many/issues/82
     "infer_ops.go",  # https://github.com/adsharma/py2many/issues/16
     "infer_ops.jl",  # https://github.com/adsharma/py2many/issues/78


### PR DESCRIPTION
Inserts a dereference precisely where it's needed

Fixes https://github.com/adsharma/py2many/issues/19