### PR TITLE
rust: add rust specific type inference

### DIFF
--- a/pyrs/declaration_extractor.py
+++ b/pyrs/declaration_extractor.py
@@ -1,13 +1,13 @@
 from py2many.declaration_extractor import (
     DeclarationExtractor as CommonDeclarationExtractor,
 )
-from .clike import rust_type_map
+from .inference import RUST_TYPE_MAP
 
 
 class DeclarationExtractor(CommonDeclarationExtractor):
     def __init__(self, transpiler):
         super().__init__(transpiler)
-        self._type_map = rust_type_map
+        self._type_map = RUST_TYPE_MAP
 
     # TODO better type infering based on variable init
     def type_by_initialization(self, init_str):

--- a/pyrs/inference.py
+++ b/pyrs/inference.py
@@ -1,0 +1,153 @@
+import ast
+from py2many.inference import get_inferred_type
+
+from ctypes import c_int8, c_int16, c_int32, c_int64
+from ctypes import c_uint8, c_uint16, c_uint32, c_uint64
+
+from py2many.analysis import get_id
+
+RUST_TYPE_MAP = {
+    "int": "i32",
+    "float": "f32",
+    "bytes": "&[u8]",
+    "str": "&str",
+    "bool": "bool",
+    "c_int8": "i8",
+    "c_int16": "i16",
+    "c_int32": "i32",
+    "c_int64": "i64",
+    "c_uint8": "u8",
+    "c_uint16": "u16",
+    "c_uint32": "u32",
+    "c_uint64": "u64",
+}
+
+
+RUST_WIDTH_RANK = {
+    "i8": 0,
+    "u8": 1,
+    "i16": 2,
+    "u16": 3,
+    "i32": 4,
+    "u32": 5,
+    "i64": 6,
+    "u64": 7,
+    "f32": 8,
+    "f64": 9,
+}
+
+
+def infer_rust_types(node):
+    visitor = InferRustTypesTransformer()
+    visitor.visit(node)
+
+
+def map_type(typename):
+    if typename in RUST_TYPE_MAP:
+        return RUST_TYPE_MAP[typename]
+    return typename
+
+
+def get_inferred_rust_type(node):
+    if isinstance(node, ast.Name):
+        if not hasattr(node, "scopes"):
+            return None
+        definition = node.scopes.find(get_id(node))
+        # Prevent infinite recursion
+        if definition != node:
+            return get_inferred_rust_type(definition)
+    if hasattr(node, "rust_annotation"):
+        return node.rust_annotation
+    python_type = get_inferred_type(node)
+    return map_type(get_id(python_type))
+
+
+class InferRustTypesTransformer(ast.NodeTransformer):
+    """Implements rust type inference logic as opposed to python type inference logic"""
+
+    FIXED_WIDTH_INTS = {
+        c_int8,
+        c_int16,
+        c_int32,
+        c_int64,
+        c_uint8,
+        c_uint16,
+        c_uint32,
+        c_uint64,
+    }
+    FIXED_WIDTH_INTS_NAME_LIST = [
+        "c_int8",
+        "c_int16",
+        "c_int32",
+        "c_int64",
+        "c_uint8",
+        "c_uint16",
+        "c_uint32",
+        "c_uint64",
+    ]
+    FIXED_WIDTH_INTS_NAME = set(FIXED_WIDTH_INTS_NAME_LIST)
+
+    def __init__(self):
+        super().__init__()
+
+    def _handle_overflow(self, op, left_id, right_id):
+        left_rust_id = map_type(left_id)
+        right_rust_id = map_type(right_id)
+
+        left_rust_rank = RUST_WIDTH_RANK.get(left_rust_id, -1)
+        right_rust_rank = RUST_WIDTH_RANK.get(right_rust_id, -1)
+
+        return left_id if left_rust_rank > right_rust_rank else right_id
+
+    def visit_BinOp(self, node):
+        self.generic_visit(node)
+
+        if isinstance(node.left, ast.Name):
+            lvar = node.scopes.find(get_id(node.left))
+        else:
+            lvar = node.left
+
+        if isinstance(node.right, ast.Name):
+            rvar = node.scopes.find(get_id(node.right))
+        else:
+            rvar = node.right
+
+        left = lvar.annotation if lvar and hasattr(lvar, "annotation") else None
+        right = rvar.annotation if rvar and hasattr(rvar, "annotation") else None
+
+        if left is None and right is not None:
+            node.rust_annotation = map_type(get_id(right))
+            return node
+
+        if right is None and left is not None:
+            node.rust_annotation = map_type(get_id(left))
+            return node
+
+        if right is None and left is None:
+            return node
+
+        # Both operands are annotated. Now we have interesting cases
+        left_id = get_id(left)
+        right_id = get_id(right)
+
+        if (
+            left_id in self.FIXED_WIDTH_INTS_NAME
+            and right_id in self.FIXED_WIDTH_INTS_NAME
+        ):
+            ret = self._handle_overflow(node.op, left_id, right_id)
+            node.rust_annotation = map_type(ret)
+            return node
+        if left_id == right_id:
+            node.annotation = left
+            node.rust_annotation = map_type(left_id)
+            return node
+        else:
+            if left_id in self.FIXED_WIDTH_INTS_NAME:
+                left_id = "int"
+            if right_id in self.FIXED_WIDTH_INTS_NAME:
+                right_id = "int"
+            if (left_id, right_id) in {("int", "float"), ("float", "int")}:
+                node.rust_annotation = map_type("float")
+                return node
+
+            raise Exception(f"type error: {left_id} {type(node.op)} {right_id}")

--- a/tests/expected/binit.rs
+++ b/tests/expected/binit.rs
@@ -5,10 +5,10 @@ fn bisect_right(data: &Vec<i32>, item: i32) -> i32 {
     let mut high: i32 = data.len() as i32;
     while low < high {
         let middle: _ = i32::from(((low + high) / 2));
-        if item < data[middle as usize] {
+        if item < data[middle as usize] as i32 {
             high = middle;
         } else {
-            low = (middle + 1);
+            low = (middle as i32 + 1);
         }
     }
     return low;

--- a/tests/expected/infer_ops.rs
+++ b/tests/expected/infer_ops.rs
@@ -4,27 +4,27 @@ fn foo() {
     let c1: i32 = (a + b);
     let c2: i32 = (a - b);
     let c3: i32 = (a * b);
-    let c4: f32 = (a / b);
+    let c4: f32 = (a / b) as f32;
     let c5: i32 = -(a);
     let d: f32 = 2.0;
-    let e1: f32 = (a + d);
-    let e2: f32 = (a - d);
-    let e3: f32 = (a * d);
-    let e4: f32 = (a / d);
+    let e1: f32 = (a as f32 + d);
+    let e2: f32 = (a as f32 - d);
+    let e3: f32 = (a as f32 * d);
+    let e4: f32 = (a as f32 / d);
     let f: f32 = -3.0;
     let g: i32 = -(a);
 }
 
 fn add1(x: i8, y: i8) -> i16 {
-    return (x + y);
+    return (x + y) as i16;
 }
 
 fn add2(x: i16, y: i16) -> i32 {
-    return (x + y);
+    return (x + y) as i32;
 }
 
 fn add3(x: i32, y: i32) -> i64 {
-    return (x + y);
+    return (x + y) as i64;
 }
 
 fn add4(x: i64, y: i64) -> i64 {
@@ -32,15 +32,15 @@ fn add4(x: i64, y: i64) -> i64 {
 }
 
 fn add5(x: u8, y: u8) -> u16 {
-    return (x + y);
+    return (x + y) as u16;
 }
 
 fn add6(x: u16, y: u16) -> u32 {
-    return (x + y);
+    return (x + y) as u32;
 }
 
 fn add7(x: u32, y: u32) -> u64 {
-    return (x + y);
+    return (x + y) as u64;
 }
 
 fn add8(x: u64, y: u64) -> u64 {
@@ -48,7 +48,7 @@ fn add8(x: u64, y: u64) -> u64 {
 }
 
 fn add9(x: i8, y: u16) -> u32 {
-    return (x + y);
+    return (x as u16 + y) as u32;
 }
 
 fn sub(x: i8, y: i8) -> i8 {
@@ -56,16 +56,16 @@ fn sub(x: i8, y: i8) -> i8 {
 }
 
 fn mul(x: i8, y: i8) -> i16 {
-    return (x * y);
+    return (x * y) as i16;
 }
 
 fn fadd1(x: i8, y: f32) -> f32 {
-    return (x + y);
+    return (x as f32 + y);
 }
 
 fn show() {
     let rv: f32 = fadd1(6, 6.0);
-    assert!(rv == 12);
+    assert!(rv == 12 as f32);
     println!("{}", "OK");
 }
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -62,7 +62,6 @@ EXPECTED_COMPILE_FAILURES = [
     "infer_ops.jl",  # https://github.com/adsharma/py2many/issues/78
     "infer_ops.kt",  # https://github.com/adsharma/py2many/issues/28
     "infer_ops.nim",  # https://github.com/adsharma/py2many/issues/16
-    "infer_ops.rs",  # https://github.com/adsharma/py2many/issues/16
     "int_enum.cpp",
     "int_enum.dart",  # https://github.com/adsharma/py2many/issues/41
     "int_enum.go",  # https://github.com/adsharma/py2many/issues/75


### PR DESCRIPTION
Fixes compile errors and some semantic errors. More work needed
for cases like:

```
fn add1(x: i8, y: i8) -> i16 {
-    return (x + y) as i16;
+    return (x as i16 + y as i16);
 }
```

so add1(127, 10) returns 137 instead of -119.

Related to https://github.com/adsharma/py2many/issues/16