### PR TITLE
tests: Lint C++ using -Wall -Werror

### DIFF
--- a/py2many/cli.py
+++ b/py2many/cli.py
@@ -40,6 +40,9 @@ from pygo.transpiler import (
 
 from py2many.rewriters import ComplexDestructuringRewriter, PythonMainRewriter
 
+PY2MANY_DIR = pathlib.Path(__file__).parent
+ROOT_DIR = PY2MANY_DIR.parent
+
 
 def transpile(source, transpiler, rewriters, transformers, post_rewriters):
     """
@@ -109,6 +112,7 @@ def cpp_settings(args):
         ["clang-format", "-i"],
         None,
         [CppListComparisonRewriter()],
+        linter=["clang++", "-std=c++14", "-I", str(ROOT_DIR), "-stdlib=libc++", "-Wall", "-Werror"]
     )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -169,8 +169,13 @@ class CodeGeneratorTests(unittest.TestCase):
                 if settings.ext == ".kt" and case_output.is_absolute():
                     # KtLint does not support absolute path in globs
                     case_output = case_output.relative_to(Path.cwd())
+                linter = settings.linter.copy()
+                if ext == ".cpp":
+                    linter.append("-Wno-unused-variable")
+                    if case == "coverage":
+                        linter.append("-Wno-null-arithmetic")
                 run(
-                    [*settings.linter, case_output],
+                    [*linter, case_output],
                     check=not expect_failure,
                 )
 


### PR DESCRIPTION
Add overrides for two errors occurring due
to the input code.