### PR TITLE
rewriters: FStringJoinRewriter

### DIFF
--- a/py2many/cli.py
+++ b/py2many/cli.py
@@ -38,7 +38,11 @@ from pygo.transpiler import (
     GoPropagateTypeAnnotation,
 )
 
-from py2many.rewriters import ComplexDestructuringRewriter, PythonMainRewriter
+from py2many.rewriters import (
+    ComplexDestructuringRewriter,
+    FStringJoinRewriter,
+    PythonMainRewriter,
+)
 
 
 def transpile(source, transpiler, rewriters, transformers, post_rewriters):
@@ -51,6 +55,7 @@ def transpile(source, transpiler, rewriters, transformers, post_rewriters):
     generic_rewriters = [
         ComplexDestructuringRewriter(language),
         PythonMainRewriter(language),
+        FStringJoinRewriter(language),
     ]
 
     # This is very basic and needs to be run before and after

--- a/py2many/cli.py
+++ b/py2many/cli.py
@@ -23,6 +23,7 @@ from pyrs.transpiler import (
     RustTranspiler,
     RustLoopIndexRewriter,
     RustNoneCompareRewriter,
+    RustStringJoinRewriter,
 )
 from pyjl.transpiler import JuliaTranspiler, JuliaMethodCallRewriter
 from pykt.inference import infer_kotlin_types
@@ -125,7 +126,7 @@ def rust_settings(args):
         None,
         [RustNoneCompareRewriter()],
         [infer_rust_types],
-        [RustLoopIndexRewriter()],
+        [RustLoopIndexRewriter(), RustStringJoinRewriter()],
     )
 
 

--- a/py2many/rewriters.py
+++ b/py2many/rewriters.py
@@ -87,3 +87,20 @@ class PythonMainRewriter(ast.NodeTransformer):
             ret.python_main = True
             return ret
         return node
+
+
+class FStringJoinRewriter(ast.NodeTransformer):
+    def __init__(self, language):
+        super().__init__()
+
+    def visit_JoinedStr(self, node):
+        new_node = ast.parse('"".join([])').body[0].value
+        args = new_node.args
+        for v in node.values:
+            if isinstance(v, ast.Constant):
+                args[0].elts.append(v)
+            elif isinstance(v, ast.FormattedValue):
+                args[0].elts.append(
+                    ast.Call(func=ast.Name(id="str"), args=[v.value], keywords=[])
+                )
+        return new_node

--- a/py2many/rewriters.py
+++ b/py2many/rewriters.py
@@ -101,6 +101,11 @@ class FStringJoinRewriter(ast.NodeTransformer):
                 args[0].elts.append(v)
             elif isinstance(v, ast.FormattedValue):
                 args[0].elts.append(
-                    ast.Call(func=ast.Name(id="str"), args=[v.value], keywords=[])
+                    ast.Call(
+                        func=ast.Name(id="str", ctx="Load"), args=[v.value], keywords=[]
+                    )
                 )
+        new_node.lineno = node.lineno
+        new_node.col_offset = node.col_offset
+        ast.fix_missing_locations(new_node)
         return new_node

--- a/tests/cases/fstring.py
+++ b/tests/cases/fstring.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+
+if __name__ == '__main__':
+    a = 10
+    print(f"hello {a+1} world")

--- a/tests/expected/fstring.rs
+++ b/tests/expected/fstring.rs
@@ -1,0 +1,15 @@
+#![allow(non_snake_case)]
+#![allow(non_upper_case_globals)]
+#![allow(unused_imports)]
+#![allow(unused_mut)]
+#![allow(unused_parens)]
+
+use std::collections;
+
+pub fn main() {
+    let a: i32 = 10;
+    println!(
+        "{}",
+        vec!["hello ", &(a + 1).to_string(), " world"].join("")
+    );
+}


### PR DESCRIPTION
This handles python's joined strings as follows:

    print(f"hello world: {a+1} number")

becomes

    println!("{}","".join(vec!["hello world: ", String::from((a + 1)), " number"]););

All we need to do now is to transpile "".join(...) in the target language,
which we need to do anyway because of how popular that construct is in
python code.

Related to: https://github.com/adsharma/py2many/issues/74