### PR TITLE
tests: make lint configurable

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,6 +84,7 @@ jobs:
         # https://github.com/sdkman/sdkman-action/issues/8
         run: |
           source "$HOME/.sdkman/bin/sdkman-init.sh"
+          LINT=1
           tox
 
   lint:

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ passenv =
     UPDATE_EXPECTED
     KEEP_GENERATED
     SHOW_ERRORS
+    LINT
     GOPATH
     GOCACHE
 deps =


### PR DESCRIPTION
May be useful for testing performance with or without checks.
Also make some of these knobs accessible from cmdline args as
well as env.

Tested via:

PYTHONPATH=. python3 tests/test_cli.py  -k go -v
PYTHONPATH=. python3 tests/test_cli.py --lint -k go -v