### PR TITLE
rewriter: move docstrings to a AST node comment field

### DIFF
--- a/py2many/cli.py
+++ b/py2many/cli.py
@@ -43,6 +43,7 @@ from py2many.rewriters import (
     ComplexDestructuringRewriter,
     FStringJoinRewriter,
     PythonMainRewriter,
+    DocStringToCommentRewriter,
 )
 
 PY2MANY_DIR = pathlib.Path(__file__).parent
@@ -63,6 +64,7 @@ def transpile(source, transpiler, rewriters, transformers, post_rewriters):
         ComplexDestructuringRewriter(language),
         PythonMainRewriter(language),
         FStringJoinRewriter(language),
+        DocStringToCommentRewriter(language),
     ]
 
     # This is very basic and needs to be run before and after
@@ -121,7 +123,15 @@ def cpp_settings(args):
         ["clang-format", "-i"],
         None,
         [CppListComparisonRewriter()],
-        linter=["clang++", "-std=c++14", "-I", str(ROOT_DIR), "-stdlib=libc++", "-Wall", "-Werror"]
+        linter=[
+            "clang++",
+            "-std=c++14",
+            "-I",
+            str(ROOT_DIR),
+            "-stdlib=libc++",
+            "-Wall",
+            "-Werror",
+        ],
     )
 
 

--- a/tests/cases/rect.py
+++ b/tests/cases/rect.py
@@ -1,12 +1,16 @@
+"""This file implements a rectangle class """
+
 from dataclasses import dataclass
 
 
 @dataclass
 class Rectangle:
+    """Rectangle as a dataclass"""
     height: int
     length: int
 
     def is_square(self) -> bool:
+        """Go likes this to be camel case"""
         return self.height == self.length
 
 

--- a/tests/test_unsupported.py
+++ b/tests/test_unsupported.py
@@ -72,7 +72,6 @@ TEST_CASES = {
     "percent_formatting": "a = '~ %s ~' % 'a'",  # https://github.com/adsharma/py2many/issues/176
     "tuple_destruct": "foo, (baz, qux) = 4, (5, 6); assert foo != (baz != qux)",  # https://github.com/adsharma/py2many/issues/155
     "float_1": "a = float(1)",  # https://github.com/adsharma/py2many/issues/129
-    "docstrings": "'''docstring'''\ndef main(): pass",  # https://github.com/adsharma/py2many/issues/7
     "print_None": "print(None)",
     "class_vars": "class A:\n  B = 'FOO'\ndef main(): assert A.B == 'FOO'",  # https://github.com/adsharma/py2many/issues/144
     "default_init": dedent(


### PR DESCRIPTION
This allows us to consume the rest of the test. The comment
can be generated from the ast node in the target language in
a future diff

Related to: https://github.com/adsharma/py2many/issues/7