### PR TITLE
dart: handle integer division in the rewriter

### DIFF
--- a/py2many/inference.py
+++ b/py2many/inference.py
@@ -295,7 +295,9 @@ class InferTypesTransformer(ast.NodeTransformer):
         right_id = get_id(right)
 
         if left_id == right_id and left_id == "int":
-            if not isinstance(node.op, ast.Div):
+            if not isinstance(node.op, ast.Div) or getattr(
+                node, "use_integer_div", False
+            ):
                 node.annotation = left
             else:
                 # TODO: This is not true for dart when using integer division

--- a/py2many/inference.py
+++ b/py2many/inference.py
@@ -131,7 +131,8 @@ class InferTypesTransformer(ast.NodeTransformer):
                     elt_type = get_id(elements[0].annotation)
                     self._annotate(node, f"List[{elt_type}]")
         else:
-            node.annotation = ast.Name(id="List")
+            if not hasattr(node, "annotation"):
+                node.annotation = ast.Name(id="List")
         return node
 
     def visit_Set(self, node):
@@ -143,7 +144,8 @@ class InferTypesTransformer(ast.NodeTransformer):
                 elt_type = get_id(elements[0].annotation)
                 self._annotate(node, f"Set[{elt_type}]")
         else:
-            node.annotation = ast.Name(id="Set")
+            if not hasattr(node, "annotation"):
+                node.annotation = ast.Name(id="Set")
         return node
 
     def visit_Dict(self, node):
@@ -168,7 +170,8 @@ class InferTypesTransformer(ast.NodeTransformer):
                 value_type = "Any"
             self._annotate(node, f"Dict[{key_type}, {value_type}]")
         else:
-            node.annotation = ast.Name(id="Dict")
+            if not hasattr(node, "annotation"):
+                node.annotation = ast.Name(id="Dict")
         return node
 
     def visit_Assign(self, node: ast.Assign) -> ast.AST:

--- a/pydart/clike.py
+++ b/pydart/clike.py
@@ -1,7 +1,6 @@
 import ast
 
 from py2many.clike import CLikeTranspiler as CommonCLikeTranspiler
-from py2many.inference import get_inferred_type, get_id
 
 
 dart_type_map = {
@@ -81,9 +80,7 @@ class CLikeTranspiler(CommonCLikeTranspiler):
         # Multiplication and division binds tighter (has higher precedence) than addition and subtraction.
         # To visually communicate this we omit spaces when multiplying and dividing.
         if isinstance(node.op, (ast.Mult, ast.Div)):
-            left_type = get_id(get_inferred_type(node.left))
-            right_type = get_id(get_inferred_type(node.right))
-            if set([left_type, right_type]) == {"int"} and isinstance(node.op, ast.Div):
+            if getattr(node, "use_integer_div", False):
                 # Use integer division operator
                 op = "~/"
             return f"({left}{op}{right})"

--- a/tests/expected/infer_ops.dart
+++ b/tests/expected/infer_ops.dart
@@ -7,7 +7,7 @@ foo() {
   final int _c1 = (a + b);
   final int _c2 = (a - b);
   final int _c3 = (a * b);
-  final double _c4 = (a ~/ b);
+  final int _c4 = (a ~/ b);
   final int _c5 = -(a);
   final double d = 2.0;
   final double _e1 = (a + d);

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -40,8 +40,7 @@ TEST_CASES = [
 EXPECTED_LINT_FAILURES = ["int_enum.go", "rect.go", "str_enum.go"]
 
 EXPECTED_COMPILE_FAILURES = [
-    "asyncio_test.rs",  # https://github.com/adsharma/py2many/issues/198
-    "infer_ops.dart",  # https://github.com/adsharma/py2many/issues/199
+    "asyncio_test.rs"  # https://github.com/adsharma/py2many/issues/198
 ]
 
 


### PR DESCRIPTION
Also rerun type inference after the post_rewriters are done.

Fixes: https://github.com/adsharma/py2many/issues/199