### PR TITLE
rust: add the langcomp benchmark test case

### DIFF
--- a/py2many/inference.py
+++ b/py2many/inference.py
@@ -196,8 +196,11 @@ class InferTypesTransformer(ast.NodeTransformer):
         self.generic_visit(node)
 
         target = node.target
-        if hasattr(node.value, "annotation"):
+        annotation = get_inferred_type(target)
+        if hasattr(node.value, "annotation") and not annotation:
             target.annotation = node.value.annotation
+        else:
+            target.annotation = annotation
 
         return node
 
@@ -368,6 +371,8 @@ class InferTypesTransformer(ast.NodeTransformer):
                 return_type = get_inferred_type(node.args[0])
                 if return_type is not None:
                     node.annotation = return_type
+            elif fname in self.TYPE_DICT.values():
+                node.annotation = ast.Name(id=fname)
         self.generic_visit(node)
         return node
 

--- a/pyrs/inference.py
+++ b/pyrs/inference.py
@@ -67,7 +67,9 @@ def get_inferred_rust_type(node):
         if definition != node:
             return get_inferred_rust_type(definition)
     python_type = get_inferred_type(node)
-    return map_type(get_id(python_type))
+    ret = map_type(get_id(python_type))
+    node.rust_annotation = ret
+    return ret
 
 
 class InferRustTypesTransformer(ast.NodeTransformer):

--- a/pyrs/transpiler.py
+++ b/pyrs/transpiler.py
@@ -616,6 +616,20 @@ class RustTranspiler(CLikeTranspiler):
         # python/rust annotations provided to customize the cast if necessary
         return f"{value_str} as {cast_to}"
 
+    def visit_AugAssign(self, node):
+        target = node.target
+        target_str = self.visit(node.target)
+        op = self.visit(node.op)
+        value = self.visit(node.value)
+
+        needs_cast = self._needs_cast(target, node.value)
+        if needs_cast:
+            target_type = self._typename_from_annotation(target)
+            value = self._assign_cast(
+                value, target_type, target.annotation, node.value.rust_annotation
+            )
+        return f"{target_str} {op}= {value};"
+
     def visit_Assign(self, node):
         target = node.targets[0]
 

--- a/tests/cases/langcomp_bench.py
+++ b/tests/cases/langcomp_bench.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+
+from typing import List
+
+
+def test_python(iterations: int):
+    iteration = 0
+    total = float(0.0)
+    array_length = 1000
+    array: List[int] = [i for i in range(array_length)]
+    print("iterations", iterations)
+    while iteration < iterations:
+        innerloop = 0
+        while innerloop < 100:
+            total += array[(iteration + innerloop) % array_length]
+            innerloop += 1
+        iteration += 1
+    if total == 15150:
+        print("OK")
+    del array
+
+
+if __name__ == "__main__":
+    test_python(3)

--- a/tests/expected/binit.cpp
+++ b/tests/expected/binit.cpp
@@ -8,7 +8,7 @@ inline int bisect_right(std::vector<int> data, int item) {
   int low = 0;
   int high = py14::to_int(data.size());
   while (low < high) {
-    auto middle = py14::to_int((low + high) / 2);
+    int middle = py14::to_int((low + high) / 2);
     if (item < data[middle]) {
       high = middle;
     } else {

--- a/tests/expected/binit.dart
+++ b/tests/expected/binit.dart
@@ -5,7 +5,7 @@ int bisect_right(List<int> data, int item) {
   int low = 0;
   int high = data.length.toInt();
   while (low < high) {
-    final middle = ((low + high) ~/ 2).toInt();
+    final int middle = ((low + high) ~/ 2).toInt();
 
     if (item < data[middle]) {
       high = middle;

--- a/tests/expected/binit.go
+++ b/tests/expected/binit.go
@@ -9,7 +9,7 @@ func bisect_right(data []int, item int) int {
 	var low int = 0
 	var high int = int(len(data))
 	for low < high {
-		middle := int(((low + high) / 2))
+		var middle int = int(((low + high) / 2))
 		if item < data[middle] {
 			high = middle
 		} else {

--- a/tests/expected/binit.kt
+++ b/tests/expected/binit.kt
@@ -7,7 +7,7 @@ fun bisect_right(data_: Array<Int>, item: Int): Int {
         if (item < data_[middle]) {
             high = middle
         } else {
-            low = (middle.toInt() + 1)
+            low = (middle + 1)
         }
     }
     return low

--- a/tests/expected/binit.rs
+++ b/tests/expected/binit.rs
@@ -10,11 +10,11 @@ pub fn bisect_right(data: &Vec<i32>, item: i32) -> i32 {
     let mut low: i32 = 0;
     let mut high: i32 = data.len() as i32;
     while low < high {
-        let middle: _ = i32::from(((low + high) / 2));
+        let middle: i32 = i32::from(((low + high) / 2));
         if item < data[middle as usize] {
             high = middle;
         } else {
-            low = (middle as i32 + 1);
+            low = (middle + 1);
         }
     }
     return low;

--- a/tests/expected/langcomp_bench.rs
+++ b/tests/expected/langcomp_bench.rs
@@ -1,0 +1,29 @@
+#![allow(non_snake_case)]
+#![allow(non_upper_case_globals)]
+#![allow(unused_imports)]
+#![allow(unused_mut)]
+#![allow(unused_parens)]
+
+pub fn test_python(iterations: i32) {
+    let mut iteration: i32 = 0;
+    let mut total: f64 = f64::from(0.0);
+    let array_length: i32 = 1000;
+    let array: Vec<i32> = (0..array_length).map(|i| i).collect::<Vec<_>>();
+    println!("{} {}", "iterations", iterations);
+    while iteration < iterations {
+        let mut innerloop: i32 = 0;
+        while innerloop < 100 {
+            total += array[((iteration + innerloop) % array_length) as usize] as f64;
+            innerloop += 1;
+        }
+        iteration += 1;
+    }
+    if total == 15150 as f64 {
+        println!("{}", "OK");
+    }
+    drop(array);
+}
+
+pub fn main() {
+    test_python(3);
+}


### PR DESCRIPTION
This is where rustc -O is 100x faster and serves to showcase
potential perf gains.

However, there was a little problem with type inference for

total += array[i]

where lhs is f64 and rhs is i32, needing a cast.