### PR TITLE
rust: use inline cargo.toml instead of cargo-deps

### DIFF
--- a/pyrs/transpiler.py
+++ b/pyrs/transpiler.py
@@ -77,7 +77,7 @@ class RustTranspiler(CLikeTranspiler):
             set(mod.split("::")[0] for mod in usings if not mod.startswith("std:"))
         )
         externs = [f"extern crate {dep};" for dep in deps]
-        deps = ",".join(deps)
+        deps = "\n//! ".join([f'{dep} = "*"' for dep in deps])
         externs = "\n".join(externs)
         uses = "\n".join(
             f"use {mod};" for mod in usings if mod not in ("strum", "lazy_static")
@@ -91,8 +91,15 @@ class RustTranspiler(CLikeTranspiler):
         #![allow(unused_parens)]
         """
         )
-        cargo_deps = f"// cargo-deps: {deps}\n" if deps else ""
-        return f"{cargo_deps}\n{lint_ignores}\n{externs}\n{uses}\n"
+        cargo_toml = f"""
+        //! ```cargo
+        //! [package]
+        //! edition = "2018"
+        //! [dependencies]
+        //! {deps}
+        //! ```
+        """
+        return f"{cargo_toml}\n{lint_ignores}\n{externs}\n{uses}\n"
 
     def features(self):
         if self._features:

--- a/tests/expected/assert.rs
+++ b/tests/expected/assert.rs
@@ -1,3 +1,11 @@
+
+//! ```cargo
+//! [package]
+//! edition = "2018"
+//! [dependencies]
+//!
+//! ```
+
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
 #![allow(unused_imports)]

--- a/tests/expected/asyncio_test.rs
+++ b/tests/expected/asyncio_test.rs
@@ -1,4 +1,10 @@
-// cargo-deps: futures
+
+//! ```cargo
+//! [package]
+//! edition = "2018"
+//! [dependencies]
+//! futures = "*"
+//! ```
 
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]

--- a/tests/expected/binit.rs
+++ b/tests/expected/binit.rs
@@ -1,3 +1,11 @@
+
+//! ```cargo
+//! [package]
+//! edition = "2018"
+//! [dependencies]
+//!
+//! ```
+
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
 #![allow(unused_imports)]

--- a/tests/expected/bubble_sort.rs
+++ b/tests/expected/bubble_sort.rs
@@ -1,3 +1,11 @@
+
+//! ```cargo
+//! [package]
+//! edition = "2018"
+//! [dependencies]
+//!
+//! ```
+
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
 #![allow(unused_imports)]

--- a/tests/expected/comb_sort.rs
+++ b/tests/expected/comb_sort.rs
@@ -1,3 +1,11 @@
+
+//! ```cargo
+//! [package]
+//! edition = "2018"
+//! [dependencies]
+//!
+//! ```
+
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
 #![allow(unused_imports)]

--- a/tests/expected/coverage.rs
+++ b/tests/expected/coverage.rs
@@ -1,3 +1,11 @@
+
+//! ```cargo
+//! [package]
+//! edition = "2018"
+//! [dependencies]
+//!
+//! ```
+
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
 #![allow(unused_imports)]

--- a/tests/expected/fib.rs
+++ b/tests/expected/fib.rs
@@ -1,3 +1,11 @@
+
+//! ```cargo
+//! [package]
+//! edition = "2018"
+//! [dependencies]
+//!
+//! ```
+
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
 #![allow(unused_imports)]

--- a/tests/expected/fstring.rs
+++ b/tests/expected/fstring.rs
@@ -1,3 +1,11 @@
+
+//! ```cargo
+//! [package]
+//! edition = "2018"
+//! [dependencies]
+//!
+//! ```
+
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
 #![allow(unused_imports)]

--- a/tests/expected/global.rs
+++ b/tests/expected/global.rs
@@ -1,3 +1,11 @@
+
+//! ```cargo
+//! [package]
+//! edition = "2018"
+//! [dependencies]
+//!
+//! ```
+
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
 #![allow(unused_imports)]

--- a/tests/expected/global2.rs
+++ b/tests/expected/global2.rs
@@ -1,4 +1,10 @@
-// cargo-deps: lazy_static
+
+//! ```cargo
+//! [package]
+//! edition = "2018"
+//! [dependencies]
+//! lazy_static = "*"
+//! ```
 
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]

--- a/tests/expected/hello_world.rs
+++ b/tests/expected/hello_world.rs
@@ -1,3 +1,11 @@
+
+//! ```cargo
+//! [package]
+//! edition = "2018"
+//! [dependencies]
+//!
+//! ```
+
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
 #![allow(unused_imports)]

--- a/tests/expected/infer.rs
+++ b/tests/expected/infer.rs
@@ -1,3 +1,11 @@
+
+//! ```cargo
+//! [package]
+//! edition = "2018"
+//! [dependencies]
+//!
+//! ```
+
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
 #![allow(unused_imports)]

--- a/tests/expected/infer_ops.rs
+++ b/tests/expected/infer_ops.rs
@@ -1,3 +1,11 @@
+
+//! ```cargo
+//! [package]
+//! edition = "2018"
+//! [dependencies]
+//!
+//! ```
+
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
 #![allow(unused_imports)]

--- a/tests/expected/int_enum.rs
+++ b/tests/expected/int_enum.rs
@@ -1,4 +1,10 @@
-// cargo-deps: flagset
+
+//! ```cargo
+//! [package]
+//! edition = "2018"
+//! [dependencies]
+//! flagset = "*"
+//! ```
 
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]

--- a/tests/expected/lambda.rs
+++ b/tests/expected/lambda.rs
@@ -1,3 +1,11 @@
+
+//! ```cargo
+//! [package]
+//! edition = "2018"
+//! [dependencies]
+//!
+//! ```
+
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
 #![allow(unused_imports)]

--- a/tests/expected/langcomp_bench.rs
+++ b/tests/expected/langcomp_bench.rs
@@ -1,3 +1,11 @@
+
+//! ```cargo
+//! [package]
+//! edition = "2018"
+//! [dependencies]
+//!
+//! ```
+
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
 #![allow(unused_imports)]

--- a/tests/expected/print.rs
+++ b/tests/expected/print.rs
@@ -1,3 +1,11 @@
+
+//! ```cargo
+//! [package]
+//! edition = "2018"
+//! [dependencies]
+//!
+//! ```
+
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
 #![allow(unused_imports)]

--- a/tests/expected/rect.rs
+++ b/tests/expected/rect.rs
@@ -1,3 +1,11 @@
+
+//! ```cargo
+//! [package]
+//! edition = "2018"
+//! [dependencies]
+//!
+//! ```
+
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
 #![allow(unused_imports)]

--- a/tests/expected/str_enum.rs
+++ b/tests/expected/str_enum.rs
@@ -1,4 +1,11 @@
-// cargo-deps: strum,strum_macros
+
+//! ```cargo
+//! [package]
+//! edition = "2018"
+//! [dependencies]
+//! strum = "*"
+//! strum_macros = "*"
+//! ```
 
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -39,9 +39,7 @@ TEST_CASES = [
 
 EXPECTED_LINT_FAILURES = ["int_enum.go", "rect.go", "str_enum.go"]
 
-EXPECTED_COMPILE_FAILURES = [
-    "asyncio_test.rs"  # https://github.com/adsharma/py2many/issues/198
-]
+EXPECTED_COMPILE_FAILURES = []
 
 
 def has_main(filename):


### PR DESCRIPTION
This allows us to specify edition for async programs.

Fixes https://github.com/adsharma/py2many/issues/198