### PR TITLE
cli: Support CXX and CXXFLAGS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,6 +49,7 @@ jobs:
           julia -e 'using Pkg; Pkg.add("JuliaFormatter")'
           julia -e 'using Pkg; Pkg.add("SuperEnum")'
           if [ "$RUNNER_OS" == "Linux" ]; then
+              sudo apt-get install --yes astyle
               curl -sSLO https://github.com/pinterest/ktlint/releases/download/0.41.0/ktlint
               chmod a+x ktlint
               sudo mv ktlint /usr/local/bin/
@@ -56,11 +57,11 @@ jobs:
               (cd /usr/local/bin && sudo ln -s $HOME/go/bin/golint)
           elif [ "$RUNNER_OS" == "macOS" ]; then
               brew tap holgerbrandl/tap https://github.com/holgerbrandl/homebrew-tap
-              brew install clang-format kscript ktlint
+              brew install clang-format kscript ktlint astyle
               (cd /usr/local/bin && ln -s $(find ~/.julia -name format.jl))
               (cd /usr/local/bin && ln -s $HOME/go/bin/golint)
           elif [ "$RUNNER_OS" == "Windows" ]; then
-              choco install zip curl
+              choco install zip curl astyle
           fi
           dart pub global activate stagehand
           curl -s "https://get.sdkman.io" | bash

--- a/py14/transpiler.py
+++ b/py14/transpiler.py
@@ -566,6 +566,7 @@ class CppTranspiler(CLikeTranspiler):
         return f"{value}[{index}]"
 
     def visit_Tuple(self, node):
+        self._headers.append("#include <tuple>")
         elts = [self.visit(e) for e in node.elts]
         return "std::make_tuple({0})".format(", ".join(elts))
 

--- a/tests/expected/bubble_sort.cpp
+++ b/tests/expected/bubble_sort.cpp
@@ -3,6 +3,7 @@
 #include "py14/runtime/sys.h"
 #include <cassert>
 #include <iostream>
+#include <tuple>
 #include <vector>
 
 inline std::vector<int> bubble_sort(std::vector<int> seq) {

--- a/tests/expected/comb_sort.cpp
+++ b/tests/expected/comb_sort.cpp
@@ -4,6 +4,7 @@
 #include <cassert>
 #include <iostream>
 #include <math.h>
+#include <tuple>
 #include <vector>
 
 inline std::vector<int> comb_sort(std::vector<int> seq) {

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,9 @@ skip_missing_interpreters = true
 passenv =
     HOME
     LocalAppData
+    CXX
+    CXXFLAGS
+    CLANG_FORMAT_STYLE
     UPDATE_EXPECTED
     KEEP_GENERATED
     SHOW_ERRORS


### PR DESCRIPTION
Adds plumbing for using with g++ only, testing with astyle as
an alternative formatter.

Also allow CLANG_FORMAT_STYLE to determine the clang-format
style to be used.