### PR TITLE
cli: make pypi package work again

### DIFF
--- a/py2many/cli.py
+++ b/py2many/cli.py
@@ -303,7 +303,7 @@ def _process_once(settings, filename, outdir, env=None):
     return True
 
 
-def main(args=None, env=None):
+def main(args=None, env=os.environ):
     parser = argparse.ArgumentParser()
     parser.add_argument("--cpp", type=bool, default=False, help="Generate C++ code")
     parser.add_argument("--rust", type=bool, default=False, help="Generate Rust code")


### PR DESCRIPTION
pypi package errors out because of env=None.