### PR TITLE
rust: support pyO3 extensions

### DIFF
--- a/py2many/analysis.py
+++ b/py2many/analysis.py
@@ -74,6 +74,23 @@ class FunctionTransformer(ast.NodeTransformer):
         self.generic_visit(node)
         return node
 
+    def _visit_Scoped(self, node):
+        node.defined_functions = []
+        self.generic_visit(node)
+        return node
+
+    def visit_ClassDef(self, node):
+        return self._visit_Scoped(node)
+
+    def visit_For(self, node):
+        return self._visit_Scoped(node)
+
+    def visit_If(self, node):
+        return self._visit_Scoped(node)
+
+    def visit_With(self, node):
+        return self._visit_Scoped(node)
+
     def visit_ImportFrom(self, node):
         for name in node.names:
             node.scopes[-1].defined_functions.append(name)

--- a/py2many/clike.py
+++ b/py2many/clike.py
@@ -55,6 +55,7 @@ class CLikeTranspiler(ast.NodeVisitor):
         self._container_type_map = {}
         self._default_type = "auto"
         self._statement_separator = ";"
+        self._extension = False
 
     def headers(self, meta=None):
         return ""
@@ -63,6 +64,13 @@ class CLikeTranspiler(ast.NodeVisitor):
         return ""
 
     def features(self):
+        return ""
+
+    @property
+    def extension(self):
+        return self._extension
+
+    def extension_module(self) -> str:
         return ""
 
     def comment(self, text):

--- a/tests/test_unsupported.py
+++ b/tests/test_unsupported.py
@@ -160,6 +160,7 @@ class CodeGeneratorTests(unittest.TestCase):
             raise RuntimeError(f"Invalid case {case}:\n{proc.stdout}{proc.stderr}")
         try:
             result = transpile(
+                "stdin",
                 tree,
                 settings.transpiler,
                 settings.rewriters,


### PR DESCRIPTION
This was tested with:

```
def sum_as_string(a: int, b: int) -> int:
    return a + b
```

py2many --rust=1 --extension=1 /tmp/foo.py

and by copying over foo.rs as src/lib.rs in a pyO3 example template.

Related to: https://github.com/adsharma/py2many/issues/62