### PR TITLE
rust: handle strings as return types

### DIFF
--- a/py2many/cli.py
+++ b/py2many/cli.py
@@ -1,5 +1,6 @@
 import argparse
 import ast
+import functools
 import os
 import pathlib
 
@@ -187,7 +188,7 @@ def rust_settings(args, env=os.environ):
         ["rustfmt", "--edition=2018"],
         None,
         [RustNoneCompareRewriter()],
-        [infer_rust_types],
+        [functools.partial(infer_rust_types, extension=args.extension)],
         [RustLoopIndexRewriter(), RustStringJoinRewriter()],
     )
 


### PR DESCRIPTION
This covers the mechanics of using PyResult from an extension.

Tested via the canonical pyO3 example:

```
def sum_as_string(a: int, b: int) -> str:
    return str(a + b)
```

Related to: https://github.com/adsharma/py2many/issues/62