### PR TITLE
inference: use classes in type_map

### DIFF
--- a/py2many/declaration_extractor.py
+++ b/py2many/declaration_extractor.py
@@ -64,13 +64,11 @@ class DeclarationExtractor(ast.NodeVisitor):
     def visit_AnnAssign(self, node, dataclass=False):
         target = node.target
         if self.is_member(target):
-            type_str = self.transpiler.visit(node.annotation)
+            type_str = self.transpiler._typename_from_annotation(node)
             if target.attr not in self.already_annotated:
                 self.already_annotated[target.attr] = type_str
         if dataclass:
-            type_str = self.transpiler.visit(node.annotation)
-            if type_str in self._type_map:
-                type_str = self._type_map[type_str]
+            type_str = self.transpiler._typename_from_annotation(node)
             if target.id not in self.already_annotated:
                 self.already_annotated[target.id] = type_str
 

--- a/pycpp/clike.py
+++ b/pycpp/clike.py
@@ -1,21 +1,24 @@
 import ast
 
+from ctypes import c_int8, c_int16, c_int32, c_int64
+from ctypes import c_uint8, c_uint16, c_uint32, c_uint64
+
 from py2many.clike import CLikeTranspiler as CommonCLikeTranspiler
 
 pycpp_type_map = {
-    "bool": "bool",
-    "int": "int",
-    "float": "double",
-    "bytes": "byte[]",
-    "str": "std::string",
-    "c_int8": "int8_t",
-    "c_int16": "int16_t",
-    "c_int32": "int32_t",
-    "c_int64": "int64_t",
-    "c_uint8": "uint8_t",
-    "c_uint16": "uint16_t",
-    "c_uint32": "uint32_t",
-    "c_uint64": "uint64_t",
+    bool: "bool",
+    int: "int",
+    float: "double",
+    bytes: "byte[]",
+    str: "std::string",
+    c_int8: "int8_t",
+    c_int16: "int16_t",
+    c_int32: "int32_t",
+    c_int64: "int64_t",
+    c_uint8: "uint8_t",
+    c_uint16: "uint16_t",
+    c_uint32: "uint32_t",
+    c_uint64: "uint64_t",
 }
 
 # Commented out keywords below so we don't break existing tests

--- a/pydart/clike.py
+++ b/pydart/clike.py
@@ -1,22 +1,25 @@
 import ast
 
+from ctypes import c_int8, c_int16, c_int32, c_int64
+from ctypes import c_uint8, c_uint16, c_uint32, c_uint64
+
 from py2many.clike import CLikeTranspiler as CommonCLikeTranspiler
 
 
 dart_type_map = {
-    "bool": "bool",
-    "int": "int",
-    "float": "double",
-    "bytes": "Uint8List",
-    "str": "String",
-    "c_int8": "int",
-    "c_int16": "int",
-    "c_int32": "int",
-    "c_int64": "int",
-    "c_uint8": "int",
-    "c_uint16": "int",
-    "c_uint32": "int",
-    "c_uint64": "int",
+    bool: "bool",
+    int: "int",
+    float: "double",
+    bytes: "Uint8List",
+    str: "String",
+    c_int8: "int",
+    c_int16: "int",
+    c_int32: "int",
+    c_int64: "int",
+    c_uint8: "int",
+    c_uint16: "int",
+    c_uint32: "int",
+    c_uint64: "int",
 }
 
 # allowed as names in Python but treated as keywords in Dart

--- a/pyjl/clike.py
+++ b/pyjl/clike.py
@@ -1,22 +1,25 @@
 import ast
 
+from ctypes import c_int8, c_int16, c_int32, c_int64
+from ctypes import c_uint8, c_uint16, c_uint32, c_uint64
+
 from py2many.clike import CLikeTranspiler as CommonCLikeTranspiler
 
 
 julia_type_map = {
-    "bool": "Bool",
-    "int": "Int64",
-    "float": "Float64",
-    "bytes": "Array{UInt8}",
-    "str": "String",
-    "c_int8": "Int8",
-    "c_int16": "Int16",
-    "c_int32": "Int32",
-    "c_int64": "Int64",
-    "c_uint8": "UInt8",
-    "c_uint16": "UInt16",
-    "c_uint32": "UInt32",
-    "c_uint64": "UInt64",
+    bool: "Bool",
+    int: "Int64",
+    float: "Float64",
+    bytes: "Array{UInt8}",
+    str: "String",
+    c_int8: "Int8",
+    c_int16: "Int16",
+    c_int32: "Int32",
+    c_int64: "Int64",
+    c_uint8: "UInt8",
+    c_uint16: "UInt16",
+    c_uint32: "UInt32",
+    c_uint64: "UInt64",
 }
 
 # allowed as names in Python but treated as keywords in Julia


### PR DESCRIPTION
Using strings in language specific type maps has the problem that it
doesn't cover the case where the type has been imported using an alias.

This is a step towards handling that correctly, although more work needs
to be done. We still have checks against FIXED_WIDTH_INTS_NAME in a few
places