### PR TITLE
rust: implement plugin based code generation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install tox
         run: pip3 install tox
 
-      - name: Install ${{ runner.os }} dependencies.
+      - name: Install Julia dependencies for ${{ runner.os }}.
         shell: bash
         run: |
           julia -e 'using Pkg; Pkg.add("JuliaFormatter")'

--- a/pyrs/plugins.py
+++ b/pyrs/plugins.py
@@ -1,0 +1,49 @@
+import textwrap
+
+try:
+    from argparse_dataclass import dataclass as ap_dataclass
+    from argparse_dataclass import ArgumentParser
+except:
+    ArgumentParser = "ArgumentParser"
+    ap_dataclass = "ap_dataclass"
+
+
+class RustTranspilerPlugins:
+    def visit_argparse_dataclass(self, node):
+        fields = []
+        for (
+            declaration,
+            typename_with_default,
+        ) in node.declarations_with_defaults.items():
+            typename, default_value = typename_with_default
+            if typename == None:
+                return None
+            if default_value is not None and typename != "bool":
+                default_value = self.visit(default_value)
+                default_value = f', default_value = "{default_value}"'
+            else:
+                default_value = ""
+            fields.append(
+                f"#[structopt(short, long{default_value})]\npub {declaration}: {typename},"
+            )
+        fields = "\n".join(fields)
+        self._usings.add("structopt::StructOpt")
+        clsdef = "\n" + textwrap.dedent(
+            f"""\
+        #[derive(Debug, StructOpt)]
+        #[structopt(name = "{self._module}", about = "Placeholder")]
+        struct {node.name} {{
+            {fields}
+        }}
+        """
+        )
+        return clsdef
+
+
+CLASS_DISPATCH_TABLE = {ap_dataclass: RustTranspilerPlugins.visit_argparse_dataclass}
+FUNC_DISPATCH_TABLE = {
+    # Uncomment after upstream uploads a new version
+    # ArgumentParser.parse_args: lambda node: "Opts::parse_args()",
+    # HACK: remove once the evaluation machinery can use the line above
+    "parse_args": lambda node: "::from_args()"
+}

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ __version__ = "0.2.1"
 
 install_requires = []
 setup_requires = []
-tests_require = ["pytest", "unittest-expander"]
+tests_require = ["pytest", "unittest-expander", "argparse_dataclass"]
 
 with open("README.md") as readme_file:
     readme = readme_file.read()

--- a/tests/cases/fib_with_argparse.py
+++ b/tests/cases/fib_with_argparse.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+
+from argparse_dataclass import dataclass
+
+
+@dataclass
+class Options:
+    v: bool = False
+    n: int = 0
+
+
+def fib(i: int) -> int:
+    if i == 0 or i == 1:
+        return 1
+    return fib(i - 1) + fib(i - 2)
+
+
+if __name__ == "__main__":
+    args = Options.parse_args()
+    if args.n == 0:
+        args.n = 5
+    print(fib(args.n))

--- a/tests/expected/fib_with_argparse.rs
+++ b/tests/expected/fib_with_argparse.rs
@@ -1,0 +1,42 @@
+
+//! ```cargo
+//! [package]
+//! edition = "2018"
+//! [dependencies]
+//! structopt = "*"
+//! ```
+
+#![allow(clippy::upper_case_acronyms)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+#![allow(non_upper_case_globals)]
+#![allow(unused_imports)]
+#![allow(unused_mut)]
+#![allow(unused_parens)]
+
+extern crate structopt;
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+#[structopt(name = "fib_with_argparse", about = "Placeholder")]
+struct Options {
+    #[structopt(short, long)]
+    pub v: bool,
+    #[structopt(short, long, default_value = "0")]
+    pub n: i32,
+}
+
+pub fn fib(i: i32) -> i32 {
+    if i == 0 || i == 1 {
+        return 1;
+    }
+    return (fib((i - 1)) + fib((i - 2)));
+}
+
+pub fn main() {
+    let mut args: _ = Options::from_args();
+    if (args.n as i32) == 0 {
+        args.n = 5;
+    }
+    println!("{}", fib(args.n));
+}

--- a/tox.ini
+++ b/tox.ini
@@ -19,5 +19,6 @@ deps =
     unittest-expander
     pytest-cov
     astpretty
+    git+https://github.com/mivade/argparse_dataclass/
 commands =
     pytest --cov --cov-config=setup.cfg -rs -v {posargs}


### PR DESCRIPTION
This allows us to keep complex use cases such as argument parsing
separate from the core transpiler.

Related to: https://github.com/adsharma/py2many/issues/179