### PR TITLE
rust: improve plugin system for file IO

### DIFF
--- a/pyrs/plugins.py
+++ b/pyrs/plugins.py
@@ -1,8 +1,11 @@
+import io
+import ast
 import textwrap
 
 try:
     from argparse_dataclass import dataclass as ap_dataclass
     from argparse_dataclass import ArgumentParser
+    from tempfile import NamedTemporaryFile
 except:
     ArgumentParser = "ArgumentParser"
     ap_dataclass = "ap_dataclass"
@@ -45,10 +48,15 @@ class RustTranspilerPlugins:
             self._usings.add("std::fs::OpenOptions")
             mode = vargs[1]
             opts = "OpenOptions::new()"
+            is_binary = "b" in mode
             for c in mode:
                 if c == "w":
+                    if not is_binary:
+                        self._usings.add("pylib::FileWriteString")
                     opts += ".write(true)"
                 if c == "r":
+                    if not is_binary:
+                        self._usings.add("pylib::FileReadString")
                     opts += ".read(true)"
                 if c == "a":
                     opts += ".append(true)"
@@ -57,12 +65,39 @@ class RustTranspilerPlugins:
             return f"{opts}.open({vargs[0]}).unwrap()"
         return f"File::open({vargs[0]}).unwrap()"
 
+    def visit_named_temp_file(self, node, vargs):
+        node.annotation = ast.Name(id="tempfile._TemporaryFileWrapper")
+        return "NamedTempFile::new().unwrap()"
+
+    def visit_textio_read(self, node, vargs):
+        # TODO
+        return None
+
+    def visit_textio_write(self, node, vargs):
+        # TODO
+        return None
+
+    def visit_ap_dataclass(self, cls):
+        # Do whatever transformation the decorator does to cls here
+        return cls
+
+
+MODULE_DISPATCH_TABLE = {"tempfile.NamedTemporaryFile": "tempfile::NamedTempFile"}
+
+DECORATOR_DISPATCH_TABLE = {ap_dataclass: RustTranspilerPlugins.visit_ap_dataclass}
 
 CLASS_DISPATCH_TABLE = {ap_dataclass: RustTranspilerPlugins.visit_argparse_dataclass}
+
 FUNC_DISPATCH_TABLE = {
     # Uncomment after upstream uploads a new version
     # ArgumentParser.parse_args: lambda node: "Opts::parse_args()",
-    # HACK: remove once the evaluation machinery can use the line above
+    # HACKs: remove all string based dispatch here, once we replace them with type based
     "parse_args": lambda self, node, vargs: "::from_args()",
+    "temp_file.name": lambda self, node, vargs: "temp_file.path()",
+    "f.read": lambda self, node, vargs: "f.read_string().unwrap",
+    "f.write": lambda self, node, vargs: "f.write_string",
     open: RustTranspilerPlugins.visit_open,
+    NamedTemporaryFile: RustTranspilerPlugins.visit_named_temp_file,
+    io.TextIOWrapper.read: RustTranspilerPlugins.visit_textio_read,
+    io.TextIOWrapper.read: RustTranspilerPlugins.visit_textio_write,
 }

--- a/tests/cases/with_open.py
+++ b/tests/cases/with_open.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 
-import tempfile
+from tempfile import NamedTemporaryFile
 
 
-if __name__ == '__main__':
-    with tempfile.NamedTemporaryFile(mode="w") as tmp:
-        with open(tmp.name, "w") as f:
+if __name__ == "__main__":
+    with NamedTemporaryFile(mode="+") as temp_file:
+        file_path = temp_file.name
+        with open(file_path, "w") as f:
             f.write("hello")
-        with open(tmp.name, "r") as f:
+        with open(file_path, "r") as f:
             print(f.read())


### PR DESCRIPTION
Introduces a companion library: pylib. This could be a submodule.
Gets us closer to with_open.py example in CI

Introduces a few new concepts:

MODULE_DISPATCH_TABLE - this is where you map module names (tempfile.xxx)
DECORATOR_DISPATCH_TABLE - tells the transpiler what the decorator is doing
FUNCTION_DISPATCH_TABLE - looked up on attributes as well as func dispatch