### PR TITLE
py2many: escape quotes in strings

### DIFF
--- a/py2many/clike.py
+++ b/py2many/clike.py
@@ -337,7 +337,9 @@ class CLikeTranspiler(ast.NodeVisitor):
             return s
 
     def visit_Str(self, node):
-        return f'"{node.value}"'
+        node_str = node.value
+        node_str = node_str.replace('"', '\\"')
+        return f'"{node_str}"'
 
     def visit_arguments(self, node) -> Tuple[List[str], List[str]]:
         args = [self.visit(arg) for arg in node.args]

--- a/tests/cases/coverage.py
+++ b/tests/cases/coverage.py
@@ -85,6 +85,8 @@ def show():
     print(s)
     assert infer_bool(1)
     # assert 1 != 2 != 3
+    # Escape quotes
+    _escape_quotes = """ foo "bar" baz """
 
 
 if __name__ == "__main__":

--- a/tests/expected/coverage.cpp
+++ b/tests/expected/coverage.cpp
@@ -112,6 +112,7 @@ inline void show() {
   std::cout << s;
   std::cout << std::endl;
   assert(infer_bool(1));
+  std::string _escape_quotes = std::string{" foo \"bar\" baz "};
 }
 
 int main(int argc, char** argv) {

--- a/tests/expected/coverage.dart
+++ b/tests/expected/coverage.dart
@@ -88,6 +88,7 @@ show() {
   final String s = "1    2";
   print(sprintf("%s", [s]));
   assert(infer_bool(1));
+  final String _escape_quotes = " foo \"bar\" baz ";
 }
 
 main() {

--- a/tests/expected/coverage.go
+++ b/tests/expected/coverage.go
@@ -109,6 +109,8 @@ func Show() {
 	if !(InferBool(1)) {
 		panic("assert")
 	}
+	var _escape_quotes string = " foo \"bar\" baz "
+	_ = _escape_quotes
 }
 
 func main() {

--- a/tests/expected/coverage.jl
+++ b/tests/expected/coverage.jl
@@ -83,6 +83,7 @@ function show()
     s = "1    2"
     println(join([s], " "))
     @assert(infer_bool(1))
+    _escape_quotes = " foo \"bar\" baz "
 end
 
 function main()

--- a/tests/expected/coverage.kt
+++ b/tests/expected/coverage.kt
@@ -96,6 +96,7 @@ fun show() {
     val s = "1    2"
     println("$s")
     assert(infer_bool(1))
+    val _escape_quotes = " foo \"bar\" baz "
 }
 
 fun main() {

--- a/tests/expected/coverage.nim
+++ b/tests/expected/coverage.nim
@@ -74,6 +74,7 @@ proc show() =
   let s = "1    2"
   echo s
   assert(infer_bool(1))
+  let _ = " foo \"bar\" baz "
 
 proc main() =
   show()

--- a/tests/expected/coverage.rs
+++ b/tests/expected/coverage.rs
@@ -103,6 +103,7 @@ pub fn show() {
     let s: &str = "1    2";
     println!("{}", s);
     assert!(infer_bool(1));
+    let _escape_quotes: &str = " foo \"bar\" baz ";
 }
 
 pub fn main() {


### PR DESCRIPTION
Fixes: https://github.com/adsharma/py2many/issues/247