### PR TITLE
rust: implement basic lifetimes for strings

### DIFF
--- a/pyrs/clike.py
+++ b/pyrs/clike.py
@@ -1,6 +1,6 @@
 import ast
 
-from py2many.clike import CLikeTranspiler as CommonCLikeTranspiler
+from py2many.clike import CLikeTranspiler as CommonCLikeTranspiler, LifeTime
 
 from .inference import (
     RUST_RANK_TO_TYPE,
@@ -38,6 +38,13 @@ class CLikeTranspiler(CommonCLikeTranspiler):
     def __init__(self):
         super().__init__()
         self._type_map = RUST_TYPE_MAP
+
+    def _map_type(self, typename, lifetime=LifeTime.UNKNOWN) -> str:
+        ret = super()._map_type(typename, lifetime)
+        if lifetime == LifeTime.STATIC:
+            assert ret[0] == "&"
+            return f"&'static {ret[1:]}"
+        return ret
 
     def visit_Name(self, node):
         if node.id in rust_keywords:

--- a/pyrs/transpiler.py
+++ b/pyrs/transpiler.py
@@ -725,7 +725,9 @@ class RustTranspiler(CLikeTranspiler):
         if not hasattr(left, "annotation") or not hasattr(right, "annotation"):
             return False
         left_type = self._typename_from_annotation(left)
-        right_type = get_inferred_rust_type(right)
+        # populate right.rust_annotation
+        get_inferred_rust_type(right)
+        right_type = self._typename_from_annotation(right)
         return left_type != right_type and left_type != self._default_type
 
     def _assign_cast(

--- a/tests/expected/coverage.rs
+++ b/tests/expected/coverage.rs
@@ -100,10 +100,10 @@ pub fn show() {
         println!("{}", "true");
     };
     inline_pass();
-    let s: &str = "1    2";
+    let s: &'static str = "1    2";
     println!("{}", s);
     assert!(infer_bool(1));
-    let _escape_quotes: &str = " foo \"bar\" baz ";
+    let _escape_quotes: &'static str = " foo \"bar\" baz ";
 }
 
 pub fn main() {

--- a/tests/expected/global.rs
+++ b/tests/expected/global.rs
@@ -19,8 +19,8 @@ use std::collections;
 pub const code_0: i32 = 0;
 pub const code_1: i32 = 1;
 pub const l_a: &[i32; 2] = &[code_0, code_1];
-pub const code_a: &str = "a";
-pub const code_b: &str = "b";
+pub const code_a: &'static str = "a";
+pub const code_b: &'static str = "b";
 pub const l_b: &[&str; 2] = &[code_a, code_b];
 pub fn main() {
     for i in l_a {

--- a/tests/expected/global2.rs
+++ b/tests/expected/global2.rs
@@ -21,8 +21,8 @@ use std::collections::HashSet;
 
 pub const code_0: i32 = 0;
 pub const code_1: i32 = 1;
-pub const code_a: &str = "a";
-pub const code_b: &str = "b";
+pub const code_a: &'static str = "a";
+pub const code_b: &'static str = "b";
 lazy_static! {
     pub static ref l_b: HashSet<&'static str> = [code_a].iter().cloned().collect::<HashSet<_>>();
 }

--- a/tests/expected/infer_ops.rs
+++ b/tests/expected/infer_ops.rs
@@ -20,7 +20,7 @@ pub fn foo() {
     let _c1: i32 = (a + b);
     let _c2: i32 = (a - b);
     let _c3: i32 = (a * b);
-    let _c4: f64 = ((a as f64) / (b as f64)) as f64;
+    let _c4: f64 = ((a as f64) / (b as f64));
     let _c5: i32 = -(a);
     let d: f64 = 2.0;
     let _e1: f64 = ((a as f64) + d);


### PR DESCRIPTION
Add an optional attribute to node.annotation. Targets that care
about it (such as rust in this diff and cpp and others in the future)
can specialize the types further.