### PR TITLE
py2many: handle funcs accessed out of order

### DIFF
--- a/pyrs/transpiler.py
+++ b/pyrs/transpiler.py
@@ -898,8 +898,11 @@ class RustTranspiler(CLikeTranspiler):
         self._features.add("generator_trait")
         self._usings.add("std::ops::Generator")
         self._usings.add("std::ops::GeneratorState")
-        value = self.visit(node.value)
-        return f"yield {value};"
+        if node.value is not None:
+            value = self.visit(node.value)
+            return f"yield {value};"
+        else:
+            return "yield None;"
 
     def visit_Print(self, node):
         buf = []

--- a/tests/test_transpile_self.py
+++ b/tests/test_transpile_self.py
@@ -31,4 +31,4 @@ class SelfTranspileTests(unittest.TestCase):
             OUT_DIR,
             _suppress_exceptions=(NotImplementedError,),
         )
-        assert len(successful) == 1  # The __init__.py
+        assert len(successful) == 4  # Four files transpile ok


### PR DESCRIPTION
Tested with:

```
from dataclasses import dataclass

def foo() -> "Point":
    return bar()

def bar() -> "Point":
    return Point(1, 2)

@dataclass
class Point:
    x: int
    y: int

if __name__ == '__main__':
    print(foo().x)
```

Fixes: https://github.com/adsharma/py2many/issues/277