### PR TITLE
rust: handle classes with class/member variables

### DIFF
--- a/py2many/clike.py
+++ b/py2many/clike.py
@@ -125,6 +125,7 @@ class CLikeTranspiler(ast.NodeVisitor):
         self._small_usings_map = {}
         self._func_dispatch_table = {}
         self._attr_dispatch_table = {}
+        self._keywords = {}
 
     def headers(self, meta=None):
         return ""

--- a/py2many/declaration_extractor.py
+++ b/py2many/declaration_extractor.py
@@ -91,8 +91,8 @@ class DeclarationExtractor(ast.NodeVisitor):
 
         if dataclass:
             type_str = self.transpiler._typename_from_annotation(node)
-            if target.id not in self.annotated_members:
-                self.annotated_members[target.id] = (type_str, node.value)
+            if get_id(target) not in self.annotated_members:
+                self.annotated_members[get_id(target)] = (type_str, node.value)
 
     def visit_Assign(self, node):
         target = node.targets[0]

--- a/py2many/declaration_extractor.py
+++ b/py2many/declaration_extractor.py
@@ -83,6 +83,12 @@ class DeclarationExtractor(ast.NodeVisitor):
             type_str = self.transpiler._typename_from_annotation(node)
             if target.attr not in self.annotated_members:
                 self.annotated_members[target.attr] = (type_str, node.value)
+        else:
+            node.class_assignment = True
+            target = get_id(target)
+            if target not in self.class_assignments:
+                self.class_assignments[target] = node.value
+
         if dataclass:
             type_str = self.transpiler._typename_from_annotation(node)
             if target.id not in self.annotated_members:
@@ -94,6 +100,7 @@ class DeclarationExtractor(ast.NodeVisitor):
             if target.attr not in self.member_assignments:
                 self.member_assignments[target.attr] = node.value
         else:
+            node.class_assignment = True
             target = get_id(target)
             if target not in self.class_assignments:
                 self.class_assignments[target] = node.value

--- a/py2many/inference.py
+++ b/py2many/inference.py
@@ -420,7 +420,10 @@ class InferTypesTransformer(ast.NodeTransformer):
                 ("List", ast.Add),
             }
 
-            if (left_id, type(node.op)) not in LEGAL_COMBINATIONS:
+            if (
+                left_id is not None
+                and (left_id, type(node.op)) not in LEGAL_COMBINATIONS
+            ):
                 err = TypeError(f"{left_id} {type(node.op)} {right_id}")
                 err.lineno, err.col_offset = node.lineno, node.col_offset
                 raise err

--- a/pyrs/clike.py
+++ b/pyrs/clike.py
@@ -11,7 +11,7 @@ from .inference import (
 
 
 # allowed as names in Python but treated as keywords in Rust
-rust_keywords = frozenset(
+RUST_KEYWORDS = frozenset(
     [
         "struct",
         "type",
@@ -38,6 +38,7 @@ class CLikeTranspiler(CommonCLikeTranspiler):
     def __init__(self):
         super().__init__()
         self._type_map = RUST_TYPE_MAP
+        self._keywords = RUST_KEYWORDS
 
     def _map_type(self, typename, lifetime=LifeTime.UNKNOWN) -> str:
         ret = super()._map_type(typename, lifetime)
@@ -47,7 +48,7 @@ class CLikeTranspiler(CommonCLikeTranspiler):
         return ret
 
     def visit_Name(self, node):
-        if node.id in rust_keywords:
+        if node.id in self._keywords:
             return node.id + "_"
         return super().visit_Name(node)
 

--- a/pyrs/inference.py
+++ b/pyrs/inference.py
@@ -158,7 +158,10 @@ class InferRustTypesTransformer(ast.NodeTransformer):
                 ("List", ast.Add),
             }
 
-            if (left_id, type(node.op)) not in LEGAL_COMBINATIONS:
+            if (
+                left_id is not None
+                and (left_id, type(node.op)) not in LEGAL_COMBINATIONS
+            ):
                 err = TypeError(f"{left_id} {type(node.op)} {right_id}")
                 err.lineno, err.col_offset = node.lineno, node.col_offset
                 raise err

--- a/pyrs/transpiler.py
+++ b/pyrs/transpiler.py
@@ -294,6 +294,8 @@ class RustTranspiler(CLikeTranspiler):
 
     def visit_Attribute(self, node):
         attr = node.attr
+        if attr in self._keywords:
+            attr = attr + "_"
 
         value_id = self.visit(node.value)
 

--- a/tests/test_unsupported.py
+++ b/tests/test_unsupported.py
@@ -124,6 +124,7 @@ EXPECTED_SUCCESSES = [
     "complex_dict.kt",
     "complex_dict.nim",
     "complex_dict.rs",
+    "class_vars.rs",
     "del.rs",
     "default_init.dart",
     "dict_get.kt",


### PR DESCRIPTION
Tested with:

```
class Foo:
    A = 1
    B = 2

    def foo(self):
        self._c = 3
```