### PR TITLE
Fix and refine test_error_cases

### DIFF
--- a/py2many/cli.py
+++ b/py2many/cli.py
@@ -17,7 +17,7 @@ from .analysis import add_imports
 from .annotation_transformer import add_annotation_flags
 from .clike import CLikeTranspiler
 from .context import add_variable_context, add_list_calls
-from .exceptions import AstNotImplementedError
+from .exceptions import AstErrorBase
 from .inference import infer_types
 from .mutability_transformer import detect_mutable_vars
 from .nesting_transformer import detect_nesting_levels
@@ -143,7 +143,7 @@ def _transpile(
             import traceback
 
             formatted_lines = traceback.format_exc().splitlines()
-            if isinstance(e, AstNotImplementedError):
+            if isinstance(e, AstErrorBase):
                 print(f"{filename}:{e.lineno}:{e.col_offset}: {formatted_lines[-1]}")
             else:
                 print(f"{filename}: {formatted_lines[-1]}")
@@ -563,7 +563,7 @@ def main(args=None, env=os.environ):
                 import traceback
 
                 formatted_lines = traceback.format_exc().splitlines()
-                if isinstance(e, AstNotImplementedError):
+                if isinstance(e, AstErrorBase):
                     print(f"{source}:{e.lineno}:{e.col_offset}: {formatted_lines[-1]}")
                 else:
                     print(f"{source}: {formatted_lines[-1]}")

--- a/py2many/cli.py
+++ b/py2many/cli.py
@@ -313,10 +313,11 @@ def dart_settings(args, env=os.environ):
 
 
 def go_settings(args, env=os.environ):
-    if os.path.exists(CWD / "revive.toml"):
-        revive_config = CWD / "revive.toml"
-    elif os.path.exists(PY2MANY_DIR / "revive.toml"):
-        revive_config = PY2MANY_DIR / "revive.toml"
+    config_filename = "revive.toml"
+    if os.path.exists(CWD / config_filename):
+        revive_config = CWD / config_filename
+    elif os.path.exists(PY2MANY_DIR / config_filename):
+        revive_config = PY2MANY_DIR / config_filename
     else:
         revive_config = None
     return LanguageSettings(

--- a/py2many/exceptions.py
+++ b/py2many/exceptions.py
@@ -1,8 +1,16 @@
 import ast
 
 
-class AstNotImplementedError(NotImplementedError):
+class AstErrorBase:
     def __init__(self, msg: str, node: ast.AST):
         self.lineno = node.lineno
         self.col_offset = node.col_offset
         super().__init__(msg)
+
+
+class AstNotImplementedError(AstErrorBase, NotImplementedError):
+    """Node is not supported by the transpiler"""
+
+
+class AstIncompatibleAssign(AstErrorBase, TypeError):
+    """Assignment target has type annotation that is incompatible with expression"""

--- a/py2many/inference.py
+++ b/py2many/inference.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 from py2many.analysis import get_id
 from py2many.clike import CLikeTranspiler, LifeTime, class_for_typename
-from py2many.exceptions import AstNotImplementedError
+from py2many.exceptions import AstIncompatibleAssign, AstNotImplementedError
 from py2many.tracer import is_enum
 
 
@@ -280,8 +280,8 @@ class InferTypesTransformer(ast.NodeTransformer):
             not is_compatible(target_class, value_class, target, node.value)
             and target_class != None
         ):
-            raise TypeError(
-                f"{target_class} incompatible with {value_class} on lineno: {node.lineno}"
+            raise AstIncompatibleAssign(
+                f"{target_class} incompatible with {value_class}", node
             )
         return node
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -65,6 +65,8 @@ EXPECTED_COMPILE_FAILURES = []
 
 CARGO_TOML = [l.strip() for l in open(ROOT_DIR / "Cargo.toml").readlines()]
 
+a_dot_out = "a.out"
+
 
 def in_cargo_toml(case: str):
     return f'path = "tests/expected/{case}.rs"' in CARGO_TOML
@@ -190,8 +192,8 @@ class CodeGeneratorTests(unittest.TestCase):
                         f.write(generated)
 
             stdout = None
-            if ext == ".cpp" and (BUILD_DIR / "a.out").exists():
-                os.rename(BUILD_DIR / "a.out", exe)
+            if ext == ".cpp" and (BUILD_DIR / a_dot_out).exists():
+                os.rename(BUILD_DIR / a_dot_out, exe)
 
             if INVOKER.get(lang):
                 invoker = INVOKER.get(lang)
@@ -285,7 +287,7 @@ class CodeGeneratorTests(unittest.TestCase):
 
         settings.formatter = ["astyle"]
 
-        exe = BUILD_DIR / "a.out"
+        exe = BUILD_DIR / a_dot_out
         exe.unlink(missing_ok=True)
 
         case_filename = TESTS_DIR / "cases" / f"{case}.py"

--- a/tests/test_transpile_self.py
+++ b/tests/test_transpile_self.py
@@ -13,10 +13,11 @@ TESTS_DIR = Path(__file__).parent
 ROOT_DIR = TESTS_DIR.parent
 OUT_DIR = TESTS_DIR / "output"
 PY2MANY_MODULE = ROOT_DIR / "py2many"
+dunder_init_dot_py = "__init__.py"
 
 
 def assert_only_init_successful(successful, format_errors=None, failures=None):
-    assert {i.name for i in successful} == {"__init__.py"}
+    assert {i.name for i in successful} == {dunder_init_dot_py}
 
 
 def assert_reformat_fails(successful, format_errors, failures):
@@ -25,15 +26,21 @@ def assert_reformat_fails(successful, format_errors, failures):
 
 
 def assert_no_failures(successful, format_errors, failures, expected_success):
+    assert {
+        i.name for i in successful if i.name != dunder_init_dot_py
+    } == expected_success
     assert not failures
-    assert {i.name for i in successful if i.name != "__init__.py"} == expected_success
 
 
 def assert_some_failures(successful, format_errors, failures, expected_success):
-    assert {i.name for i in successful if i.name != "__init__.py"} == expected_success
+    assert {
+        i.name for i in successful if i.name != dunder_init_dot_py
+    } == expected_success
+    assert failures
 
 
 def assert_only_reformat_failures(successful, format_errors, failures):
+    assert successful
     assert not failures
     assert format_errors
 
@@ -97,28 +104,10 @@ class SelfTranspileTests(unittest.TestCase):
         if suppress_exceptions:
             raise unittest.SkipTest(f"{settings.formatter[0]} not available")
 
-        assert_no_failures(
+        assert_only_reformat_failures(
             successful,
             format_errors,
             failures,
-            expected_success={
-                "__main__.py",
-                "analysis.py",
-                "annotation_transformer.py",
-                "cli.py",
-                "clike.py",
-                "context.py",
-                "declaration_extractor.py",
-                "exceptions.py",
-                "inference.py",
-                "mutability_transformer.py",
-                "nesting_transformer.py",
-                "result.py",
-                "rewriters.py",
-                "scope.py",
-                "tracer.py",
-                "toposort_modules.py",
-            },
         )
 
     def test_go_recursive(self):

--- a/tests/test_unsupported.py
+++ b/tests/test_unsupported.py
@@ -12,6 +12,7 @@ import astpretty
 from unittest_expander import foreach, expand
 
 from py2many.cli import _get_all_settings, _relative_to_cwd, _transpile, _transpile_one
+from py2many.exceptions import AstIncompatibleAssign
 
 import py2many.cli
 
@@ -170,8 +171,8 @@ EXPECTED_SUCCESSES = [
 ]
 
 TEST_ERROR_CASES = {
-    "a: i8 = 300 ": TypeError,
-    "a: i8 = 10; b: i16 = 300; c: i16 = a + b": TypeError,
+    "a: i8 = 300": AstIncompatibleAssign,
+    "a: i8 = 10; b: i16 = 300; c: i16 = a + b": AstIncompatibleAssign,
 }
 
 

--- a/tests/test_unsupported.py
+++ b/tests/test_unsupported.py
@@ -11,7 +11,7 @@ import astpretty
 
 from unittest_expander import foreach, expand
 
-from py2many.cli import _get_all_settings, _relative_to_cwd, _transpile
+from py2many.cli import _get_all_settings, _relative_to_cwd, _transpile, _transpile_one
 
 import py2many.cli
 
@@ -322,8 +322,8 @@ class CodeGeneratorTests(unittest.TestCase):
         if proc.returncode:
             raise RuntimeError(f"Invalid case {case}:\n{proc.stdout}{proc.stderr}")
         try:
-            _transpile(
-                "stdin",
+            _transpile_one(
+                [tree],
                 tree,
                 settings.transpiler,
                 settings.rewriters,


### PR DESCRIPTION
This also shows why the transpilers should not use TypeError.  As predicted, that causes real exceptions to not be noticed.