### PR TITLE
visit_ImportFrom fix and NamedExpr not implemented

### DIFF
--- a/py2many/clike.py
+++ b/py2many/clike.py
@@ -527,6 +527,10 @@ class CLikeTranspiler(ast.NodeVisitor):
                 f"{name} unimplemented on line {node.lineno}:{node.col_offset}"
             )
 
+    def visit_NamedExpr(self, node):
+        target = self.visit(node.target)
+        return self.visit_unsupported_body(node, f"named expr {target}", node.value)
+
     def visit_Delete(self, node):
         body = [self.visit(t) for t in node.targets]
         return self.visit_unsupported_body(node, "del", body)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py3{8,9}
+envlist = py3{8,9,10}
 skip_missing_interpreters = true
 
 [testenv]
@@ -16,7 +16,7 @@ passenv =
     GOPATH
     GOCACHE
 deps =
-    unittest-expander
+    git+https://github.com/zuo/unittest_expander
     pytest-cov
     black
     astpretty


### PR DESCRIPTION
AttributeError occurs because node.module is None
when `from . import ...`