### PR TITLE
rust: streamline assign one

### DIFF
--- a/tests/expected/bubble_sort.rs
+++ b/tests/expected/bubble_sort.rs
@@ -28,7 +28,7 @@ use anyhow::Result;
 use std::collections;
 
 pub fn bubble_sort(seq: &mut Vec<i32>) -> Vec<i32> {
-    let L: _ = seq.len();
+    let L = seq.len();
     for _ in (0..L) {
         for n in (1..L) {
             if seq[n as usize] < seq[((n as i32) - 1) as usize] {

--- a/tests/expected/cls.rs
+++ b/tests/expected/cls.rs
@@ -35,7 +35,7 @@ impl Foo {
 }
 pub fn main() -> Result<()> {
     let f: Foo = Foo {};
-    let b: _ = f.bar();
+    let b = f.bar();
     println!("{}", b);
     Ok(())
 }

--- a/tests/expected/comb_sort.rs
+++ b/tests/expected/comb_sort.rs
@@ -29,7 +29,7 @@ use std::cmp;
 use std::collections;
 
 pub fn comb_sort(seq: &mut Vec<i32>) -> Vec<i32> {
-    let mut gap: _ = seq.len();
+    let mut gap = seq.len();
     let mut swap: bool = true;
     while (gap as i32) > 1 || swap {
         gap = cmp::max(1, ((gap as f64) / 1.25).floor() as usize);

--- a/tests/expected/coverage.rs
+++ b/tests/expected/coverage.rs
@@ -72,7 +72,7 @@ pub fn show() {
     let a3: i32 = -(a1);
     let a4: i32 = (a3 + a1);
     println!("{}", a4);
-    let t1: _ = if a1 > 5 { 10 } else { 5 };
+    let t1 = if a1 > 5 { 10 } else { 5 };
     assert!((t1 as i32) == 10);
     let sum1: i32 = indexing();
     println!("{}", sum1);

--- a/tests/expected/fib_with_argparse.rs
+++ b/tests/expected/fib_with_argparse.rs
@@ -46,7 +46,7 @@ pub fn fib(i: i32) -> i32 {
 }
 
 pub fn main() -> Result<()> {
-    let mut args: _ = Options::from_args();
+    let mut args = Options::from_args();
     if (args.n as i32) == 0 {
         args.n = 5;
     }

--- a/tests/expected/sealed.rs
+++ b/tests/expected/sealed.rs
@@ -63,10 +63,10 @@ impl Register {
 }
 
 pub fn main() -> Result<()> {
-    let a: _ = Register::VALUE(10);
+    let a = Register::VALUE(10);
     assert!(a.is_value());
     a.value();
-    let b: _ = Register::PACKET(Packet { val: 1.3 });
+    let b = Register::PACKET(Packet { val: 1.3 });
     assert!(b.is_packet());
     b.packet();
     println!("{}", "OK");

--- a/tests/expected/with_open.rs
+++ b/tests/expected/with_open.rs
@@ -38,14 +38,14 @@ use std::fs::OpenOptions;
 use tempfile::NamedTempFile;
 pub fn main() -> Result<()> {
     ({
-        let temp_file: _ = NamedTempFile::new()?;
-        let file_path: _ = temp_file.path();
+        let temp_file = NamedTempFile::new()?;
+        let file_path = temp_file.path();
         ({
-            let mut f: _ = OpenOptions::new().write(true).open(file_path)?;
+            let mut f = OpenOptions::new().write(true).open(file_path)?;
             f.write_string("hello")?;
         });
         ({
-            let mut f: _ = OpenOptions::new().read(true).open(file_path)?;
+            let mut f = OpenOptions::new().read(true).open(file_path)?;
             assert!(std::str::from_utf8(&f.read_bytes(1)?)? == "h");
             assert!(f.read_string()? == "ello");
             println!("{}", "OK");


### PR DESCRIPTION
Steps before we consolidate the special casing by type into fewer
code paths. Probably move some of the logic around lazy static
out of the function.

Starting with rust because it has the largest assign one func.

Related to: https://github.com/adsharma/py2many/issues/410