### PR TITLE
ci: Run CI on all branches

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,15 +1,7 @@
 name: CI
 
 # Controls when the action will run.
-on:
-  # Triggers the workflow on push or pull request events but only for the main branch
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
-
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:


### PR DESCRIPTION
When I first started working on the V PR, I was confused on why the CI didn't run on my branch. The main only setup is unusual and not exactly optimal in my opinion. It forces people to either do work only on the main branch, make a PR to the main branch in this repo or manually run the workflows everytime.