### PR TITLE
typing: add annotations

### DIFF
--- a/pycpp/clike.py
+++ b/pycpp/clike.py
@@ -136,13 +136,13 @@ class CLikeTranspiler(CommonCLikeTranspiler):
             return name + "_", True
         return name, False
 
-    def visit_Name(self, node):
+    def visit_Name(self, node) -> str:
         node_id, changed = self._check_keyword(node.id)
         if changed:
             return node_id
         return super().visit_Name(node)
 
-    def visit_BinOp(self, node):
+    def visit_BinOp(self, node) -> str:
         if isinstance(node.op, ast.Pow):
             return "std::pow({0}, {1})".format(
                 self.visit(node.left), self.visit(node.right)
@@ -159,7 +159,7 @@ class CLikeTranspiler(CommonCLikeTranspiler):
             right = f"({right})"
         return " ".join([left, self.visit(node.op), right])
 
-    def visit_In(self, node):
+    def visit_In(self, node) -> str:
         self._usings.add("<algorithm>")
         left_str = self.visit(node.left)
         right = node.comparators[0]

--- a/pydart/clike.py
+++ b/pydart/clike.py
@@ -67,12 +67,12 @@ class CLikeTranspiler(CommonCLikeTranspiler):
         super().__init__()
         self._type_map = dart_type_map
 
-    def visit_Name(self, node):
+    def visit_Name(self, node) -> str:
         if node.id in dart_keywords:
             return node.id + "_"
         return super().visit_Name(node)
 
-    def visit_BinOp(self, node):
+    def visit_BinOp(self, node) -> str:
         if isinstance(node.op, ast.Pow):
             return "pow({0}, {1})".format(self.visit(node.left), self.visit(node.right))
 
@@ -90,7 +90,7 @@ class CLikeTranspiler(CommonCLikeTranspiler):
         else:
             return f"({left} {op} {right})"
 
-    def visit_In(self, node):
+    def visit_In(self, node) -> str:
         left = self.visit(node.left)
         right = self.visit(node.comparators[0])
         return "{0}.any({1})".format(right, left)

--- a/pygo/clike.py
+++ b/pygo/clike.py
@@ -67,18 +67,18 @@ class CLikeTranspiler(CommonCLikeTranspiler):
         super().__init__()
         self._type_map = GO_TYPE_MAP
 
-    def visit(self, node):
+    def visit(self, node) -> str:
         if type(node) in go_symbols:
             return go_symbol(node)
         else:
             return super().visit(node)
 
-    def visit_Name(self, node):
+    def visit_Name(self, node) -> str:
         if node.id in go_keywords:
             return node.id + "_"
         return super().visit_Name(node)
 
-    def visit_BinOp(self, node):
+    def visit_BinOp(self, node) -> str:
         if isinstance(node.op, ast.Pow):
             self._usings.add('"math"')
             return "math.Pow({0}, {1})".format(
@@ -107,7 +107,7 @@ class CLikeTranspiler(CommonCLikeTranspiler):
         else:
             return f"({left} {op} {right})"
 
-    def visit_In(self, node):
+    def visit_In(self, node) -> str:
         self._usings.add('"github.com/adsharma/py2many/pygo/runtime"')
         element = self.visit(node.left)
         container = node.comparators[0]

--- a/pyjl/clike.py
+++ b/pyjl/clike.py
@@ -75,18 +75,18 @@ class CLikeTranspiler(CommonCLikeTranspiler):
         super().__init__()
         self._type_map = julia_type_map
 
-    def visit(self, node):
+    def visit(self, node) -> str:
         if type(node) in jl_symbols:
             return jl_symbol(node)
         else:
             return super().visit(node)
 
-    def visit_Name(self, node):
+    def visit_Name(self, node) -> str:
         if node.id in julia_keywords:
             return node.id + "_"
         return super().visit_Name(node)
 
-    def visit_BinOp(self, node):
+    def visit_BinOp(self, node) -> str:
         if isinstance(node.op, ast.Pow):
             return "pow({0}, {1})".format(self.visit(node.left), self.visit(node.right))
 
@@ -102,7 +102,7 @@ class CLikeTranspiler(CommonCLikeTranspiler):
                 self.visit(node.left), self.visit(node.op), self.visit(node.right)
             )
 
-    def visit_In(self, node):
+    def visit_In(self, node) -> str:
         left = self.visit(node.left)
         right = self.visit(node.comparators[0])
         return f"{left} in {right}"

--- a/pykt/clike.py
+++ b/pykt/clike.py
@@ -103,13 +103,13 @@ class CLikeTranspiler(CommonCLikeTranspiler):
             return self._get_temp(), True
         return name, False
 
-    def visit_Name(self, node):
+    def visit_Name(self, node) -> str:
         node_id, changed = self._check_keyword(node.id)
         if changed:
             return node_id
         return super().visit_Name(node)
 
-    def visit_BinOp(self, node):
+    def visit_BinOp(self, node) -> str:
         if isinstance(node.op, ast.Pow):
             return "pow({0}, {1})".format(self.visit(node.left), self.visit(node.right))
 
@@ -135,7 +135,7 @@ class CLikeTranspiler(CommonCLikeTranspiler):
         else:
             return f"({left} {op} {right})"
 
-    def visit_Compare(self, node):
+    def visit_Compare(self, node) -> str:
         if isinstance(node.ops[0], ast.In):
             return self.visit_In(node)
 
@@ -157,7 +157,7 @@ class CLikeTranspiler(CommonCLikeTranspiler):
 
         return f"{left} {op} {right}"
 
-    def visit_In(self, node):
+    def visit_In(self, node) -> str:
         left = self.visit(node.left)
         right = self.visit(node.comparators[0])
         return f"{left} in {right}"

--- a/pykt/transpiler.py
+++ b/pykt/transpiler.py
@@ -105,7 +105,7 @@ class KotlinTranspiler(CLikeTranspiler):
         uses = "\n".join(f"import {mod}" for mod in usings)
         return uses
 
-    def visit_FunctionDef(self, node):
+    def visit_FunctionDef(self, node) -> str:
         body = "\n".join([self.visit(n) for n in node.body])
         typenames, args = self.visit_arguments(node.args)
 
@@ -149,7 +149,7 @@ class KotlinTranspiler(CLikeTranspiler):
         funcdef = f"fun {node.name}{template}({args}){return_type} {{"
         return funcdef + "\n" + body + "}\n\n"
 
-    def visit_Return(self, node):
+    def visit_Return(self, node) -> str:
         if node.value:
             ret = self.visit(node.value)
             fndef = None
@@ -175,13 +175,13 @@ class KotlinTranspiler(CLikeTranspiler):
             typename = self._typename_from_annotation(node)
         return (typename, id)
 
-    def visit_Lambda(self, node):
+    def visit_Lambda(self, node) -> str:
         _, args = self.visit(node.args)
         args_string = ", ".join(args)
         body = self.visit(node.body)
         return f"{{ {args_string} -> {body} }}"
 
-    def visit_Attribute(self, node):
+    def visit_Attribute(self, node) -> str:
         attr = node.attr
 
         value_id = self.visit(node.value)
@@ -201,7 +201,7 @@ class KotlinTranspiler(CLikeTranspiler):
 
         return f"{value_id}.{attr}"
 
-    def visit_Call(self, node):
+    def visit_Call(self, node) -> str:
         fname = self.visit(node.func)
         vargs = []
 
@@ -230,7 +230,7 @@ class KotlinTranspiler(CLikeTranspiler):
 
         return f"{fname}({args})"
 
-    def visit_For(self, node):
+    def visit_For(self, node) -> str:
         target = self.visit(node.target)
         it = self.visit(node.iter)
         buf = []
@@ -239,20 +239,20 @@ class KotlinTranspiler(CLikeTranspiler):
         buf.append("}")
         return "\n".join(buf)
 
-    def visit_Str(self, node):
+    def visit_Str(self, node) -> str:
         return "" + super().visit_Str(node) + ""
 
-    def visit_Bytes(self, node):
+    def visit_Bytes(self, node) -> str:
         bytes_str = "{0}".format(node.s)
         return bytes_str.replace("'", '"')  # replace single quote with double quote
 
-    def visit_Name(self, node):
+    def visit_Name(self, node) -> str:
         if node.id == "None":
             return "None"
         else:
             return super().visit_Name(node)
 
-    def visit_NameConstant(self, node):
+    def visit_NameConstant(self, node) -> str:
         if node.value is None:
             return "null"
         else:
@@ -265,13 +265,13 @@ class KotlinTranspiler(CLikeTranspiler):
         buf.append("}")
         return "\n".join(buf)
 
-    def visit_If(self, node):
+    def visit_If(self, node) -> str:
         body_vars = set([get_id(v) for v in node.scopes[-1].body_vars])
         orelse_vars = set([get_id(v) for v in node.scopes[-1].orelse_vars])
         node.common_vars = body_vars.intersection(orelse_vars)
         return super().visit_If(node)
 
-    def visit_UnaryOp(self, node):
+    def visit_UnaryOp(self, node) -> str:
         if isinstance(node.op, ast.USub):
             if isinstance(node.operand, (ast.Call, ast.Num)):
                 # Shortcut if parenthesis are not needed
@@ -281,7 +281,7 @@ class KotlinTranspiler(CLikeTranspiler):
         else:
             return super().visit_UnaryOp(node)
 
-    def visit_BinOp(self, node):
+    def visit_BinOp(self, node) -> str:
         if (
             isinstance(node.left, ast.List)
             and isinstance(node.op, ast.Mult)
@@ -293,7 +293,7 @@ class KotlinTranspiler(CLikeTranspiler):
         else:
             return super().visit_BinOp(node)
 
-    def visit_ClassDef(self, node):
+    def visit_ClassDef(self, node) -> str:
         extractor = DeclarationExtractor(KotlinTranspiler())
         extractor.visit(node)
         declarations = node.declarations = extractor.get_declarations()
@@ -337,7 +337,7 @@ class KotlinTranspiler(CLikeTranspiler):
             body = "\n".join(body)
             return f"class {node.name} {{\n{fields}\n\n {body}\n}}\n"
 
-    def _visit_enum(self, node, typename: str, fields: List[Tuple]):
+    def _visit_enum(self, node, typename: str, fields: List[Tuple]) -> str:
         fields_list = []
 
         for field, value in fields:
@@ -349,7 +349,7 @@ class KotlinTranspiler(CLikeTranspiler):
         fields_str = "".join(fields_list)
         return f"enum class {node.name}(val value: {typename}) {{\n{fields_str}\n}}"
 
-    def visit_StrEnum(self, node):
+    def visit_StrEnum(self, node) -> str:
         fields = []
         for i, (member, var) in enumerate(node.class_assignments.items()):
             var = self.visit(var)
@@ -358,7 +358,7 @@ class KotlinTranspiler(CLikeTranspiler):
             fields.append((member, var))
         return self._visit_enum(node, "String", fields)
 
-    def visit_IntEnum(self, node):
+    def visit_IntEnum(self, node) -> str:
         fields = []
         for i, (member, var) in enumerate(node.class_assignments.items()):
             var = self.visit(var)
@@ -367,7 +367,7 @@ class KotlinTranspiler(CLikeTranspiler):
             fields.append((member, var))
         return self._visit_enum(node, "Int", fields)
 
-    def visit_IntFlag(self, node):
+    def visit_IntFlag(self, node) -> str:
         fields = []
         for i, (member, var) in enumerate(node.class_assignments.items()):
             var = self.visit(var)
@@ -389,23 +389,23 @@ class KotlinTranspiler(CLikeTranspiler):
                 return f"from {kt_module_name} import {kt_name}"
         return "\n".join([f"import {module_name}.{name}" for name in names])
 
-    def visit_List(self, node):
+    def visit_List(self, node) -> str:
         elements = [self.visit(e) for e in node.elts]
         elements_str = ", ".join(elements)
         return f"arrayOf({elements_str})"
 
-    def visit_Set(self, node):
+    def visit_Set(self, node) -> str:
         elements = [self.visit(e) for e in node.elts]
         elements_str = ", ".join(elements)
         return f"setOf({elements_str})"
 
-    def visit_Dict(self, node):
+    def visit_Dict(self, node) -> str:
         keys = [self.visit(k) for k in node.keys]
         values = [self.visit(k) for k in node.values]
         kv_pairs = ", ".join([f"{k} to {v}" for k, v in zip(keys, values)])
         return f"hashMapOf({kv_pairs})"
 
-    def visit_Subscript(self, node):
+    def visit_Subscript(self, node) -> str:
         value = self.visit(node.value)
         index = self.visit(node.slice)
         if hasattr(node, "is_annotation"):
@@ -423,10 +423,10 @@ class KotlinTranspiler(CLikeTranspiler):
         )
         return f"{value}[{index}]!!" if is_container_dict else f"{value}[{index}]"
 
-    def visit_Index(self, node):
+    def visit_Index(self, node) -> str:
         return self.visit(node.value)
 
-    def visit_Slice(self, node):
+    def visit_Slice(self, node) -> str:
         lower = ""
         if node.lower:
             lower = self.visit(node.lower)
@@ -436,14 +436,14 @@ class KotlinTranspiler(CLikeTranspiler):
 
         return "{0}..{1}".format(lower, upper)
 
-    def visit_Tuple(self, node):
+    def visit_Tuple(self, node) -> str:
         elts = [self.visit(e) for e in node.elts]
         elts = ", ".join(elts)
         if hasattr(node, "is_annotation"):
             return elts
         return "({0})".format(elts)
 
-    def visit_Try(self, node, finallybody=None):
+    def visit_Try(self, node, finallybody=None) -> str:
         buf = self.visit_unsupported_body(node, "try_dummy", node.body)
 
         for handler in node.handlers:
@@ -455,7 +455,7 @@ class KotlinTranspiler(CLikeTranspiler):
 
         return "\n".join(buf)
 
-    def visit_ExceptHandler(self, node):
+    def visit_ExceptHandler(self, node) -> str:
         exception_type = ""
         if node.type:
             exception_type = self.visit(node.type)
@@ -463,11 +463,11 @@ class KotlinTranspiler(CLikeTranspiler):
         body = self.visit_unsupported_body(node, name, node.body)
         return body
 
-    def visit_Assert(self, node):
+    def visit_Assert(self, node) -> str:
         condition = self.visit(node.test)
         return f"assert({condition})"
 
-    def visit_AnnAssign(self, node):
+    def visit_AnnAssign(self, node) -> str:
         target = self.visit(node.target)
         type_str = self._typename_from_annotation(node)
         val = self.visit(node.value) if node.value is not None else None
@@ -475,7 +475,7 @@ class KotlinTranspiler(CLikeTranspiler):
             return f"var {target} = {val}"
         return f"var {target}: {type_str} = {val}"
 
-    def _visit_AssignOne(self, node, target):
+    def _visit_AssignOne(self, node, target) -> str:
         kw = "var" if is_mutable(node.scopes, get_id(target)) else "val"
 
         if isinstance(target, ast.Tuple):
@@ -517,44 +517,44 @@ class KotlinTranspiler(CLikeTranspiler):
 
             return f"{kw} {target} = {value}"
 
-    def visit_Delete(self, node):
+    def visit_Delete(self, node) -> str:
         target = node.targets[0]
         return "{0}.drop()".format(self.visit(target))
 
-    def visit_Raise(self, node):
+    def visit_Raise(self, node) -> str:
         if node.exc is not None:
             exc = self.visit(node.exc)
             return f"throw Exception({exc})"
         return "throw Exception()"
 
-    def visit_Await(self, node):
+    def visit_Await(self, node) -> str:
         expr = self.visit(node.value)
         return f"{expr}.await()"
 
-    def visit_AsyncFunctionDef(self, node):
+    def visit_AsyncFunctionDef(self, node) -> str:
         fn = self.visit_FunctionDef(node)
         return f"suspend {fn}"
 
-    def visit_Yield(self, node):
+    def visit_Yield(self, node) -> str:
         return "//yield is unimplemented"
 
-    def visit_Print(self, node):
+    def visit_Print(self, node) -> str:
         vargs_str = " ".join([f"${arg}" for arg in node.values])
         return f'println("{vargs_str}")'
 
-    def visit_GeneratorExp(self, node):
+    def visit_GeneratorExp(self, node) -> str:
         return "GeneratorExp /*unimplemented()*/"
 
-    def visit_ListComp(self, node):
+    def visit_ListComp(self, node) -> str:
         return self.visit_GeneratorExp(node)  # right now they are the same
 
-    def visit_Global(self, node):
+    def visit_Global(self, node) -> str:
         return "//global {0}".format(", ".join(node.names))
 
-    def visit_Starred(self, node):
+    def visit_Starred(self, node) -> str:
         return "starred!({0})/*unsupported*/".format(self.visit(node.value))
 
-    def visit_IfExp(self, node):
+    def visit_IfExp(self, node) -> str:
         body = self.visit(node.body)
         orelse = self.visit(node.orelse)
         test = self.visit(node.test)

--- a/pynim/clike.py
+++ b/pynim/clike.py
@@ -118,16 +118,16 @@ class CLikeTranspiler(CommonCLikeTranspiler):
         self._type_map = NIM_TYPE_MAP
         self._statement_separator = ""
 
-    def visit(self, node):
+    def visit(self, node) -> str:
         if type(node) in nim_symbols:
             return nim_symbol(node)
         else:
             return super().visit(node)
 
-    def visit_Ellipsis(self, node):
+    def visit_Ellipsis(self, node) -> str:
         return "discard"
 
-    def visit_BinOp(self, node):
+    def visit_BinOp(self, node) -> str:
         if isinstance(node.op, ast.Pow):
             left = self.visit(node.left)
             right = self.visit(node.right)
@@ -150,14 +150,14 @@ class CLikeTranspiler(CommonCLikeTranspiler):
 
         return f"({left} {op} {right})"
 
-    def visit_Name(self, node):
+    def visit_Name(self, node) -> str:
         if node.id in nim_keywords:
             return node.id + "_"
         if node.id.startswith("_"):
             return "_"
         return super().visit_Name(node)
 
-    def visit_In(self, node):
+    def visit_In(self, node) -> str:
         left = self.visit(node.left)
         right = self.visit(node.comparators[0])
         left_type = self._typename_from_annotation(node.left)

--- a/pyrs/clike.py
+++ b/pyrs/clike.py
@@ -47,12 +47,12 @@ class CLikeTranspiler(CommonCLikeTranspiler):
             return f"&'static {ret[1:]}"
         return ret
 
-    def visit_Name(self, node):
+    def visit_Name(self, node) -> str:
         if node.id in self._keywords:
             return node.id + "_"
         return super().visit_Name(node)
 
-    def visit_BinOp(self, node):
+    def visit_BinOp(self, node) -> str:
         if isinstance(node.op, ast.Pow):
             return "pow({0}, {1})".format(self.visit(node.left), self.visit(node.right))
 
@@ -88,7 +88,7 @@ class CLikeTranspiler(CommonCLikeTranspiler):
         else:
             return f"({left} {op} {right})"
 
-    def visit_Compare(self, node):
+    def visit_Compare(self, node) -> str:
         if isinstance(node.ops[0], ast.In):
             return self.visit_In(node)
 
@@ -116,7 +116,7 @@ class CLikeTranspiler(CommonCLikeTranspiler):
 
         return f"{left} {op} {right}"
 
-    def visit_In(self, node):
+    def visit_In(self, node) -> str:
         left = self.visit(node.left)
         right = self.visit(node.comparators[0])
         return "{0}.any({1})".format(right, left)

--- a/pyv/transpiler.py
+++ b/pyv/transpiler.py
@@ -159,7 +159,7 @@ class VTranspiler(CLikeTranspiler):
 
         return " ".join(signature)
 
-    def visit_FunctionDef(self, node):
+    def visit_FunctionDef(self, node) -> str:
         body = "\n".join([self.indent(self.visit(n)) for n in node.body])
         return f"{self.function_signature(node)} {{\n{body}\n}}"
 
@@ -365,7 +365,7 @@ class VTranspiler(CLikeTranspiler):
 
         return "{0}..{1}".format(lower, upper)
 
-    def visit_Elipsis(self, node):
+    def visit_Elipsis(self, node) -> str:
         return ""
 
     def visit_Tuple(self, node: ast.Tuple) -> str:


### PR DESCRIPTION
```
sed -i '/^class.*Transpiler/,$s/^\(.*visit\)\([^>]*\):$/\1\2 -> str:/' */transpiler.py */clike.py
```

and then removed anything that caused extra type errors. Mostly visit_arg() which returns a tuple