### PR TITLE
v: pin vc to fix CI issue

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,9 +43,13 @@ jobs:
           git clone --single-branch https://github.com/vlang/v.git /tmp/v
           (cd /tmp/v && git checkout 02f0a3055515c8e13b5e016ef266b346b705e3d3)
           if [ "$RUNNER_OS" == "Windows" ]; then
-            (cd /tmp/v && ./make.bat)
+            (cd /tmp/v && git clone https://github.com/vlang/vc.git)
+            (cd /tmp/v/thirdparty && git clone --depth 1 --single-branch --branch thirdparty-windows-amd64 https://github.com/vlang/tccbin.git tcc)
+            (cd /tmp/v/vc && git checkout 3a67714ab8134cbbf0276ce3418592dbe73c7a15)
+            (cd /tmp/v && ./make.bat --local)
           else
-            (cd /tmp/v && make -j4)
+            (cd /tmp/v && mkdir -p vc && curl -o vc/v.c https://raw.githubusercontent.com/vlang/vc/3a67714ab8134cbbf0276ce3418592dbe73c7a15/v.c)
+            (cd /tmp/v && local=1 make -j4)
             (cd /usr/local/bin && sudo ln -s /tmp/v/v)
           fi
 


### PR DESCRIPTION
It seems that while pinning V version to a specific commit, I have not considered the fact that the V's Makefile always fetching latest v.c could break bootstrapping. This PR addresses that by also pinning the version of v.c.

I know this is not ideal, I'll work on getting up-to-date, pre-built builds but in the mean time the CI should not fail for others.