### PR TITLE
smt: cleanup pipe based usage

### DIFF
--- a/py2many/cli.py
+++ b/py2many/cli.py
@@ -678,7 +678,7 @@ def main(args=None, env=os.environ):
             outdir = Path(args.outdir)
 
         if source.is_file() or source.name == STDIN:
-            print(f"Writing to: {outdir}")
+            print(f"Writing to: {outdir}", file=sys.stderr)
             try:
                 rv = _process_one(settings, source, outdir, args, env)
             except Exception as e:
@@ -686,9 +686,12 @@ def main(args=None, env=os.environ):
 
                 formatted_lines = traceback.format_exc().splitlines()
                 if isinstance(e, AstErrorBase):
-                    print(f"{source}:{e.lineno}:{e.col_offset}: {formatted_lines[-1]}")
+                    print(
+                        f"{source}:{e.lineno}:{e.col_offset}: {formatted_lines[-1]}",
+                        file=sys.stderr,
+                    )
                 else:
-                    print(f"{source}: {formatted_lines[-1]}")
+                    print(f"{source}: {formatted_lines[-1]}", file=sys.stderr)
                 rv = False
         else:
             if args.outdir is None:

--- a/pysmt/transpiler.py
+++ b/pysmt/transpiler.py
@@ -392,7 +392,7 @@ class SmtTranspiler(CLikeTranspiler):
 
     def visit_List(self, node):
         elements = [self.visit(e) for e in node.elts]
-        elements = ", ".join(elements)
+        elements = " ".join(elements)
         return f"@[{elements}]"
 
     def visit_Set(self, node):
@@ -434,7 +434,7 @@ class SmtTranspiler(CLikeTranspiler):
 
     def visit_Tuple(self, node):
         elts = [self.visit(e) for e in node.elts]
-        elts = ", ".join(elts)
+        elts = " ".join(elts)
         if hasattr(node, "is_annotation"):
             return elts
         return "({0})".format(elts)

--- a/tests/cases/equations.py
+++ b/tests/cases/equations.py
@@ -8,6 +8,6 @@ y < 10
 x + 2 * y == 7
 
 check_sat()
-get_model()
+get_value((x, y))
 
 # z3 -smt2 equations.smt prints: x = 7, y = 0

--- a/tests/expected/equations.smt
+++ b/tests/expected/equations.smt
@@ -5,4 +5,4 @@
 (assert (< y 10))
 (assert (= (+ x (* 2 y)) 7))
 (check-sat)
-(get-model)
+(get-value (x y))


### PR DESCRIPTION
- write info to stderr instead of stdout
- handle tuple transpilation
- use get-value instead of get-model in tests

Tested via:

cat tests/cases/equations.py | ./py2many.py --smt=1 - | z3 -smt2 -in