### PR TITLE
rust: use cargo new

### DIFF
--- a/py2many/clike.py
+++ b/py2many/clike.py
@@ -329,7 +329,7 @@ class CLikeTranspiler(ast.NodeVisitor):
     def _import(self, name: str) -> str:
         ...
 
-    def _import_from(self, module_name: str, names: List[str]) -> str:
+    def _import_from(self, module_name: str, names: List[str], level: int = 0) -> str:
         ...
 
     def visit_Import(self, node) -> str:
@@ -371,7 +371,7 @@ class CLikeTranspiler(ast.NodeVisitor):
             else:
                 self._imported_names[asname] = (imported_name, name)
         names = [n for n, _ in names]
-        return self._import_from(imported_name, names)
+        return self._import_from(imported_name, names, node.level)
 
     def visit_Name(self, node) -> str:
         if node.id in self.builtin_constants:

--- a/py2many/language.py
+++ b/py2many/language.py
@@ -17,6 +17,10 @@ class LanguageSettings:
     transformers: List[Callable] = field(default_factory=list)
     post_rewriters: List[ast.NodeVisitor] = field(default_factory=list)
     linter: Optional[List[str]] = None
+    # Create a language specific project structure
+    create_project: Optional[List[str]] = None
+    # Rust likes source files to live in {project}/src for example
+    project_subdir: Optional[str] = None
 
     def __hash__(self):
         f = tuple(self.formatter) if self.formatter is not None else ()

--- a/pycpp/transpiler.py
+++ b/pycpp/transpiler.py
@@ -484,7 +484,7 @@ class CppTranspiler(CLikeTranspiler):
             return f"#include {name}"
         return f'#include "{name}.h"'
 
-    def _import_from(self, module_name: str, names: List[str]) -> str:
+    def _import_from(self, module_name: str, names: List[str], level: int = 0) -> str:
         if len(names) == 1:
             # TODO: make this more generic so it works for len(names) > 1
             name = names[0]

--- a/pydart/transpiler.py
+++ b/pydart/transpiler.py
@@ -385,7 +385,7 @@ class DartTranspiler(CLikeTranspiler):
     def _import(self, name: str) -> str:
         return f'import "{name}";'
 
-    def _import_from(self, module_name: str, names: List[str]) -> str:
+    def _import_from(self, module_name: str, names: List[str], level: int = 0) -> str:
         if len(names) == 1:
             # TODO: make this more generic so it works for len(names) > 1
             name = names[0]

--- a/pygo/transpiler.py
+++ b/pygo/transpiler.py
@@ -489,7 +489,7 @@ class GoTranspiler(CLikeTranspiler):
     def _import(self, name: str) -> str:
         return f'import ("{name}")'
 
-    def _import_from(self, module_name: str, names: List[str]) -> str:
+    def _import_from(self, module_name: str, names: List[str], level: int = 0) -> str:
         if len(names) == 1:
             # TODO: make this more generic so it works for len(names) > 1
             name = names[0]

--- a/pyjl/transpiler.py
+++ b/pyjl/transpiler.py
@@ -396,7 +396,7 @@ class JuliaTranspiler(CLikeTranspiler):
     def _import(self, name: str) -> str:
         return f"import {name}"
 
-    def _import_from(self, module_name: str, names: List[str]) -> str:
+    def _import_from(self, module_name: str, names: List[str], level: int = 0) -> str:
         if len(names) == 1:
             # TODO: make this more generic so it works for len(names) > 1
             name = names[0]

--- a/pykt/transpiler.py
+++ b/pykt/transpiler.py
@@ -379,7 +379,7 @@ class KotlinTranspiler(CLikeTranspiler):
     def _import(self, name: str) -> str:
         return f"import {name};"
 
-    def _import_from(self, module_name: str, names: List[str]) -> str:
+    def _import_from(self, module_name: str, names: List[str], level: int = 0) -> str:
         if len(names) == 1:
             # TODO: make this more generic so it works for len(names) > 1
             name = names[0]

--- a/pynim/transpiler.py
+++ b/pynim/transpiler.py
@@ -375,7 +375,7 @@ class NimTranspiler(CLikeTranspiler):
     def _import(self, name: str) -> str:
         return f"import {name}"
 
-    def _import_from(self, module_name: str, names: List[str]) -> str:
+    def _import_from(self, module_name: str, names: List[str], level: int = 0) -> str:
         names = ", ".join(names)
         if len(names) == 1:
             # TODO: make this more generic so it works for len(names) > 1

--- a/pysmt/transpiler.py
+++ b/pysmt/transpiler.py
@@ -379,7 +379,7 @@ class SmtTranspiler(CLikeTranspiler):
     def _import(self, name: str) -> str:
         return f"import {name}"
 
-    def _import_from(self, module_name: str, names: List[str]) -> str:
+    def _import_from(self, module_name: str, names: List[str], level: int = 0) -> str:
         names = ", ".join(names)
         if len(names) == 1:
             # TODO: make this more generic so it works for len(names) > 1

--- a/pyv/transpiler.py
+++ b/pyv/transpiler.py
@@ -176,7 +176,7 @@ class VTranspiler(CLikeTranspiler):
         # Suppress all imports for now until a reliable way to differentiate submodule imports is used.
         return ""
 
-    def _import_from(self, module_name: str, names: List[str]) -> str:
+    def _import_from(self, module_name: str, names: List[str], level: int = 0) -> str:
         # Suppress all imports for now until a reliable way to differentiate submodule imports is used.
         return ""  # f"import {module_name} {{{' '.join(names)}}}"
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -461,6 +461,7 @@ class CodeGeneratorTests(unittest.TestCase):
         args = [
             f"--{lang}=1",
             str(case_dirname),
+            "--project=0",
             "--outdir",
             str(output_dir),
         ]

--- a/tests/test_transpile_self.py
+++ b/tests/test_transpile_self.py
@@ -59,7 +59,7 @@ class SelfTranspileTests(unittest.TestCase):
         transpiler_module = ROOT_DIR / "pyrs"
         assert_only_reformat_failures(
             *_process_dir(
-                settings, transpiler_module, OUT_DIR, _suppress_exceptions=False
+                settings, transpiler_module, OUT_DIR, False, _suppress_exceptions=False
             )
         )
 
@@ -68,7 +68,7 @@ class SelfTranspileTests(unittest.TestCase):
 
         assert_only_reformat_failures(
             *_process_dir(
-                settings, PY2MANY_MODULE, OUT_DIR, _suppress_exceptions=False
+                settings, PY2MANY_MODULE, OUT_DIR, False, _suppress_exceptions=False
             ),
         )
 
@@ -78,13 +78,13 @@ class SelfTranspileTests(unittest.TestCase):
         transpiler_module = ROOT_DIR / "pydart"
         assert_only_reformat_failures(
             *_process_dir(
-                settings, transpiler_module, OUT_DIR, _suppress_exceptions=False
+                settings, transpiler_module, OUT_DIR, False, _suppress_exceptions=False
             ),
         )
 
         assert_only_reformat_failures(
             *_process_dir(
-                settings, PY2MANY_MODULE, OUT_DIR, _suppress_exceptions=False
+                settings, PY2MANY_MODULE, OUT_DIR, False, _suppress_exceptions=False
             ),
         )
 
@@ -102,12 +102,17 @@ class SelfTranspileTests(unittest.TestCase):
                 settings,
                 transpiler_module,
                 OUT_DIR,
+                False,
                 _suppress_exceptions=suppress_exceptions,
             )
         )
 
         successful, format_errors, failures = _process_dir(
-            settings, PY2MANY_MODULE, OUT_DIR, _suppress_exceptions=suppress_exceptions
+            settings,
+            PY2MANY_MODULE,
+            OUT_DIR,
+            False,
+            _suppress_exceptions=suppress_exceptions,
         )
         if suppress_exceptions:
             raise unittest.SkipTest(f"{settings.formatter[0]} not available")
@@ -128,6 +133,7 @@ class SelfTranspileTests(unittest.TestCase):
                 settings,
                 transpiler_module,
                 OUT_DIR,
+                False,
                 _suppress_exceptions=suppress_exceptions,
             ),
             expected_success=set(["transpiler.py"]),
@@ -138,6 +144,7 @@ class SelfTranspileTests(unittest.TestCase):
                 settings,
                 PY2MANY_MODULE,
                 OUT_DIR,
+                False,
                 _suppress_exceptions=suppress_exceptions,
             ),
             expected_success={
@@ -172,6 +179,7 @@ class SelfTranspileTests(unittest.TestCase):
                 settings,
                 transpiler_module,
                 OUT_DIR,
+                False,
                 _suppress_exceptions=False,
             )
         )
@@ -180,6 +188,7 @@ class SelfTranspileTests(unittest.TestCase):
                 settings,
                 PY2MANY_MODULE,
                 OUT_DIR,
+                False,
                 _suppress_exceptions=False,
             ),
         )
@@ -192,12 +201,13 @@ class SelfTranspileTests(unittest.TestCase):
             settings,
             transpiler_module,
             OUT_DIR,
+            False,
             _suppress_exceptions=False,
         )
         assert len(successful) >= 11
 
         successful, format_errors, failures = _process_dir(
-            settings, PY2MANY_MODULE, OUT_DIR, _suppress_exceptions=False
+            settings, PY2MANY_MODULE, OUT_DIR, False, _suppress_exceptions=False
         )
         assert len(successful) >= 15
 
@@ -215,13 +225,18 @@ class SelfTranspileTests(unittest.TestCase):
             settings,
             transpiler_module,
             OUT_DIR,
+            False,
             _suppress_exceptions=suppress_exceptions,
         )
         if FileNotFoundError not in suppress_exceptions:
             assert_only_reformat_failures(successful, format_errors, failures)
 
         successful, format_errors, failures = _process_dir(
-            settings, PY2MANY_MODULE, OUT_DIR, _suppress_exceptions=suppress_exceptions
+            settings,
+            PY2MANY_MODULE,
+            OUT_DIR,
+            False,
+            _suppress_exceptions=suppress_exceptions,
         )
         if FileNotFoundError in suppress_exceptions:
             raise unittest.SkipTest(f"{settings.formatter[0]} not available")


### PR DESCRIPTION
This allows directory mode transpilation to create a Cargo.toml
via cargo new --bin.

Any relative imports are transpiled to `mod name` instead of
`extern create name`.

Tested via:

```
head /tmp/foo/*.py
==> /tmp/foo/foo1.py <==
def foo1():
    return 42

==> /tmp/foo/main.py <==
from .foo1 import foo1

def main():
    print(foo1())

py2many --rust=1 /tmp/foo --outdir /tmp/rustfoo
cd /tmp/rustfoo
cargo run
42
```

Related to: https://github.com/adsharma/py2many/issues/408